### PR TITLE
fix: format Notes/Agenda/Reminders dates using OS locale

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import ctypes
+import locale
 import queue
 import threading
 import time
@@ -13,6 +14,12 @@ except Exception:
         ctypes.windll.user32.SetProcessDPIAware()
     except Exception:
         pass
+
+# Use the OS locale for date/time formatting (%x, %X).
+try:
+    locale.setlocale(locale.LC_TIME, "")
+except locale.Error:
+    pass
 
 _STOP = object()  # sentinel to shut down pipeline workers
 

--- a/notes_window.py
+++ b/notes_window.py
@@ -9,6 +9,7 @@ Features:
 """
 
 import json
+import re
 import tkinter as tk
 from datetime import datetime
 
@@ -20,6 +21,21 @@ import database as db
 import locales
 from brand import make_title_bar_image
 import theme as T
+
+
+_SECONDS_RE = re.compile(r"\D\d{2}(?=\D*$)")
+
+
+def _format_dt_os(dt: datetime) -> str:
+    """Format a datetime using the OS locale's short date and time (no seconds).
+
+    Examples (time portion):
+        09:11:00     -> 09:11
+        9:11:00 AM   -> 9:11 AM
+        09.11.00     -> 09.11
+    """
+    return f"{dt.strftime('%x')}  {_SECONDS_RE.sub('', dt.strftime('%X'))}"
+
 
 _WIN_W, _WIN_H = 520, 600
 _MIN_W, _MIN_H = 380, 400
@@ -335,7 +351,7 @@ class NotesWindow:
             # Timestamp
             try:
                 ts = datetime.fromisoformat(note["updated_at"])
-                ts_str = ts.strftime("%d/%m/%Y  %H:%M")
+                ts_str = _format_dt_os(ts)
             except Exception:
                 ts_str = note["updated_at"]
             ctk.CTkLabel(inner, text=ts_str, font=T.FONT_SMALL,
@@ -398,7 +414,7 @@ class NotesWindow:
 
             try:
                 dt = datetime.fromisoformat(a["dt"])
-                dt_str = dt.strftime("%d/%m/%Y  %H:%M")
+                dt_str = _format_dt_os(dt)
             except Exception:
                 dt_str = a["dt"]
             ctk.CTkLabel(inner, text=f"📅  {dt_str}", font=T.FONT_BODY,
@@ -441,7 +457,7 @@ class NotesWindow:
 
             try:
                 dt = datetime.fromisoformat(r["remind_at"])
-                dt_str = dt.strftime("%d/%m/%Y  %H:%M")
+                dt_str = _format_dt_os(dt)
             except Exception:
                 dt_str = r["remind_at"]
             ctk.CTkLabel(inner, text=dt_str, font=T.FONT_SMALL,


### PR DESCRIPTION
## Summary
- Dates in the Notes/Agenda/Reminders window were hardcoded to `dd/MM/yyyy  HH:mm`, which doesn't match users whose OS region uses a different short-date format (e.g. `yyyy-MM-dd`).
- `main.py` now calls `locale.setlocale(LC_TIME, "")` once at startup so `strftime("%x")` / `strftime("%X")` follow the OS region settings.
- Notes/Agenda/Reminders cards now render dates via a small `_format_dt_os` helper that uses `%x %X` and strips seconds (the original UI didn't show them).

## Test plan
- [ ] Launch the app, open the Notes window
- [ ] Verify each tab (Notes, Agenda, Reminders) renders dates in your OS short-date format
- [ ] Verify times render without seconds
- [ ] Change OS region settings (e.g. to a different short-date pattern), restart, confirm formatting follows

<img width="503" height="213" alt="image" src="https://github.com/user-attachments/assets/bf8e0390-cb7e-4571-b2d5-04d5abed2a3f" />
