### PR TITLE
fix: preserve clipboard contents and exit cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ WHISPER_LANGUAGE = None
 # Clipboard behaviour after paste. False = restore previous clipboard.
 KEEP_TRANSCRIPT_IN_CLIPBOARD = False
 
+# Seconds to wait before restoring prior clipboard contents.
+CLIPBOARD_RESTORE_DELAY = 0.5
+
 # Recording mode
 HOLD_TO_RECORD = True          # True = hold key, False = toggle (press/press)
 MAX_RECORD_SECONDS = 120       # Safety timeout for toggle mode (seconds)

--- a/config.py
+++ b/config.py
@@ -39,6 +39,9 @@ OLLAMA_MODEL = "llama3.1:8b"
 # False = save the user's clipboard before paste and restore it after.
 KEEP_TRANSCRIPT_IN_CLIPBOARD = False
 
+# Seconds to wait before restoring the clipboard (increase for slow apps).
+CLIPBOARD_RESTORE_DELAY = 0.5
+
 # ── Recording mode ────────────────────────────────────────────────────────
 # True = hold key to record (release stops).  False = toggle (press start, press stop).
 HOLD_TO_RECORD = True

--- a/hotkey.py
+++ b/hotkey.py
@@ -174,3 +174,4 @@ class HotkeyListener:
     def stop(self):
         if self._listener is not None:
             self._listener.stop()
+            self._listener.join(timeout=1.0)

--- a/injector.py
+++ b/injector.py
@@ -23,7 +23,16 @@ _keyboard = Controller()
 _user32 = ctypes.windll.user32
 _kernel32 = ctypes.windll.kernel32
 
+CF_BITMAP = 2
+CF_METAFILEPICT = 3
+CF_PALETTE = 9
 CF_UNICODETEXT = 13
+CF_ENHMETAFILE = 14
+CF_OWNERDISPLAY = 0x0080
+CF_DSPBITMAP = 0x0082
+CF_DSPMETAFILEPICT = 0x0083
+CF_DSPENHMETAFILE = 0x008E
+GMEM_MOVEABLE = 0x0002
 
 _OpenClipboard = _user32.OpenClipboard
 _OpenClipboard.argtypes = [ctypes.wintypes.HWND]
@@ -38,12 +47,23 @@ _EmptyClipboard.argtypes = []
 _EmptyClipboard.restype = ctypes.wintypes.BOOL
 
 _SetClipboardData = _user32.SetClipboardData
-_SetClipboardData.argtypes = [ctypes.wintypes.UINT, ctypes.wintypes.HANDLE]
+_SetClipboardData.argtypes = [
+    ctypes.wintypes.UINT,
+    ctypes.wintypes.HANDLE,
+]
 _SetClipboardData.restype = ctypes.wintypes.HANDLE
 
 _GetClipboardData = _user32.GetClipboardData
 _GetClipboardData.argtypes = [ctypes.wintypes.UINT]
 _GetClipboardData.restype = ctypes.wintypes.HANDLE
+
+_EnumClipboardFormats = _user32.EnumClipboardFormats
+_EnumClipboardFormats.argtypes = [ctypes.wintypes.UINT]
+_EnumClipboardFormats.restype = ctypes.wintypes.UINT
+
+_GetClipboardSequenceNumber = _user32.GetClipboardSequenceNumber
+_GetClipboardSequenceNumber.argtypes = []
+_GetClipboardSequenceNumber.restype = ctypes.wintypes.DWORD
 
 _GlobalAlloc = _kernel32.GlobalAlloc
 _GlobalAlloc.argtypes = [ctypes.wintypes.UINT, ctypes.c_size_t]
@@ -57,63 +77,303 @@ _GlobalUnlock = _kernel32.GlobalUnlock
 _GlobalUnlock.argtypes = [ctypes.wintypes.HANDLE]
 _GlobalUnlock.restype = ctypes.wintypes.BOOL
 
-GMEM_MOVEABLE = 0x0002
+_GlobalFree = _kernel32.GlobalFree
+_GlobalFree.argtypes = [ctypes.wintypes.HANDLE]
+_GlobalFree.restype = ctypes.wintypes.HANDLE
+
+_ole32 = ctypes.windll.ole32
+_OleDuplicateData = _ole32.OleDuplicateData
+_OleDuplicateData.argtypes = [
+    ctypes.wintypes.HANDLE,
+    ctypes.wintypes.UINT,
+    ctypes.wintypes.UINT,
+]
+_OleDuplicateData.restype = ctypes.wintypes.HANDLE
+
+_gdi32 = ctypes.windll.gdi32
+_DeleteObject = _gdi32.DeleteObject
+_DeleteObject.argtypes = [ctypes.wintypes.HANDLE]
+_DeleteObject.restype = ctypes.wintypes.BOOL
+
+_CopyEnhMetaFile = _gdi32.CopyEnhMetaFileW
+_CopyEnhMetaFile.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.LPCWSTR]
+_CopyEnhMetaFile.restype = ctypes.wintypes.HANDLE
+
+_DeleteEnhMetaFile = _gdi32.DeleteEnhMetaFile
+_DeleteEnhMetaFile.argtypes = [ctypes.wintypes.HANDLE]
+_DeleteEnhMetaFile.restype = ctypes.wintypes.BOOL
+
+_DeleteMetaFile = _gdi32.DeleteMetaFile
+_DeleteMetaFile.argtypes = [ctypes.wintypes.HANDLE]
+_DeleteMetaFile.restype = ctypes.wintypes.BOOL
+
+
+class _METAFILEPICT(ctypes.Structure):
+    _fields_ = [
+        ("mm", ctypes.wintypes.LONG),
+        ("xExt", ctypes.wintypes.LONG),
+        ("yExt", ctypes.wintypes.LONG),
+        ("hMF", ctypes.wintypes.HANDLE),
+    ]
 
 _MAX_RETRIES = 5
-_RETRY_DELAY = 0.02  # seconds
+_RESTORE_RETRIES = 25
+_SET_DATA_RETRIES = 3
+_RETRY_DELAY = 0.02
 
 
 # ── Clipboard helpers ─────────────────────────────────────────────────────
 
-def _open_clipboard() -> bool:
+def _open_clipboard(retries: int = _MAX_RETRIES) -> bool:
     """Try to open the clipboard with retries (another app may hold it)."""
-    for _ in range(_MAX_RETRIES):
+    for _ in range(retries):
         if _OpenClipboard(None):
             return True
         time.sleep(_RETRY_DELAY)
     return False
 
 
-def _get_clipboard_text() -> str:
-    """Return current clipboard text, or empty string on failure."""
-    if not _open_clipboard():
-        log.warning("Cannot open clipboard for reading")
-        return ""
+def _allocate_clipboard_text(text: str):
+    """Allocate a movable UTF-16 block suitable for SetClipboardData."""
+    encoded = text.encode("utf-16-le") + b"\x00\x00"
+    h_mem = _GlobalAlloc(GMEM_MOVEABLE, len(encoded))
+    if not h_mem:
+        return None
+    ptr = _GlobalLock(h_mem)
+    if not ptr:
+        _GlobalFree(h_mem)
+        return None
     try:
-        handle = _GetClipboardData(CF_UNICODETEXT)
-        if not handle:
-            return ""
+        ctypes.memmove(ptr, encoded, len(encoded))
+    finally:
+        _GlobalUnlock(h_mem)
+    return h_mem
+
+
+def _duplicate_clipboard_handle(format_id: int, handle):
+    """Duplicate one clipboard handle, including enhanced metafiles."""
+    if format_id in {CF_ENHMETAFILE, CF_DSPENHMETAFILE}:
+        return _CopyEnhMetaFile(handle, None)
+    return _OleDuplicateData(handle, format_id, GMEM_MOVEABLE)
+
+
+def _free_clipboard_handle(format_id: int, handle):
+    """Free a duplicated handle that was not transferred to Windows."""
+    if not handle:
+        return
+    if format_id in {CF_BITMAP, CF_PALETTE, CF_DSPBITMAP}:
+        _DeleteObject(handle)
+    elif format_id in {CF_ENHMETAFILE, CF_DSPENHMETAFILE}:
+        _DeleteEnhMetaFile(handle)
+    elif format_id in {CF_METAFILEPICT, CF_DSPMETAFILEPICT}:
         ptr = _GlobalLock(handle)
-        if not ptr:
-            return ""
-        try:
-            return ctypes.wstring_at(ptr)
-        finally:
-            _GlobalUnlock(handle)
+        if ptr:
+            try:
+                metafile = ctypes.cast(
+                    ptr, ctypes.POINTER(_METAFILEPICT)).contents
+                if metafile.hMF:
+                    _DeleteMetaFile(metafile.hMF)
+            finally:
+                _GlobalUnlock(handle)
+        _GlobalFree(handle)
+    else:
+        _GlobalFree(handle)
+
+
+def _free_clipboard_snapshot(snapshot):
+    for format_id, handle in snapshot:
+        _free_clipboard_handle(format_id, handle)
+
+
+def _capture_open_clipboard():
+    """Duplicate each available format while the clipboard is open."""
+    snapshot = []
+    format_id = _EnumClipboardFormats(0)
+    while format_id:
+        # CF_OWNERDISPLAY is meaningful only while its original owner remains
+        # the clipboard owner and has no portable data handle to duplicate.
+        if format_id == CF_OWNERDISPLAY:
+            log.error("Cannot safely preserve CF_OWNERDISPLAY clipboard data")
+            _free_clipboard_snapshot(snapshot)
+            return None
+
+        handle = _GetClipboardData(format_id)
+        if not handle:
+            log.error("Cannot read clipboard format %d", format_id)
+            _free_clipboard_snapshot(snapshot)
+            return None
+        duplicate = _duplicate_clipboard_handle(format_id, handle)
+        if not duplicate:
+            log.error("Cannot duplicate clipboard format %d", format_id)
+            _free_clipboard_snapshot(snapshot)
+            return None
+        snapshot.append((format_id, duplicate))
+        format_id = _EnumClipboardFormats(format_id)
+    return snapshot
+
+
+def _set_clipboard_data_with_retries(format_id: int, handle) -> bool:
+    """Transfer one handle to Windows, retrying transient failures."""
+    for attempt in range(_SET_DATA_RETRIES):
+        if _SetClipboardData(format_id, handle):
+            return True
+        if attempt + 1 < _SET_DATA_RETRIES:
+            time.sleep(_RETRY_DELAY)
+    return False
+
+
+def _swap_clipboard_for_text(text: str):
+    """Atomically preserve all clipboard formats and replace them with text.
+
+    Returns ``(snapshot, sequence_number)`` on success. The snapshot owns its
+    handles until they are restored or explicitly freed.
+    """
+    text_handle = _allocate_clipboard_text(text)
+    if not text_handle:
+        return None
+    if not _open_clipboard():
+        log.warning("Cannot open clipboard for backup")
+        _GlobalFree(text_handle)
+        return None
+
+    snapshot = None
+    succeeded = False
+    transferred = False
+    try:
+        snapshot = _capture_open_clipboard()
+        if snapshot is None:
+            return None
+        if not _EmptyClipboard():
+            return None
+        if not _set_clipboard_data_with_retries(
+                CF_UNICODETEXT, text_handle):
+            # EmptyClipboard already destroyed the original. Restore the
+            # snapshot immediately before reporting the failed swap.
+            for format_id, handle in snapshot:
+                if _set_clipboard_data_with_retries(format_id, handle):
+                    continue
+                _free_clipboard_handle(format_id, handle)
+            snapshot = []
+            return None
+        transferred = True
+        succeeded = True
     finally:
         _CloseClipboard()
+        if not transferred:
+            _GlobalFree(text_handle)
+            if snapshot:
+                _free_clipboard_snapshot(snapshot)
+    if not succeeded:
+        return None
+    # Windows may synthesize compatible formats when the clipboard closes,
+    # which can advance the sequence number. Record it only after CloseClipboard.
+    return snapshot, _GetClipboardSequenceNumber()
+
+
+def _open_clipboard_text() -> str | None:
+    """Read Unicode text while the caller holds the clipboard open."""
+    handle = _GetClipboardData(CF_UNICODETEXT)
+    if not handle:
+        return None
+    ptr = _GlobalLock(handle)
+    if not ptr:
+        return None
+    try:
+        return ctypes.wstring_at(ptr)
+    finally:
+        _GlobalUnlock(handle)
+
+
+def _restore_clipboard(
+        snapshot, expected_sequence: int, expected_text: str | None = None
+) -> bool:
+    """Restore a snapshot unless another program changed the clipboard."""
+    if not _open_clipboard(_RESTORE_RETRIES):
+        log.warning("Cannot open clipboard for restoration")
+        _free_clipboard_snapshot(snapshot)
+        return False
+
+    remaining = list(snapshot)
+    try:
+        sequence_matches = (
+            _GetClipboardSequenceNumber() == expected_sequence)
+        text_matches = (
+            expected_text is None or _open_clipboard_text() == expected_text)
+        if not sequence_matches or not text_matches:
+            log.info("Clipboard changed during paste; skipping restoration")
+            return False
+        if not _EmptyClipboard():
+            return False
+
+        restored_all = True
+        while remaining:
+            format_id, handle = remaining.pop(0)
+            if not _set_clipboard_data_with_retries(format_id, handle):
+                log.error("Cannot restore clipboard format %d", format_id)
+                _free_clipboard_handle(format_id, handle)
+                restored_all = False
+                continue
+            # Windows owns each successfully restored handle.
+        return restored_all
+    finally:
+        _CloseClipboard()
+        _free_clipboard_snapshot(remaining)
 
 
 def _set_clipboard_text(text: str) -> bool:
     """Write *text* to the clipboard. Returns True on success."""
+    h_mem = _allocate_clipboard_text(text)
+    if not h_mem:
+        return False
+
     if not _open_clipboard():
         log.warning("Cannot open clipboard for writing")
+        _GlobalFree(h_mem)
         return False
+
+    transferred = False
     try:
-        _EmptyClipboard()
-        encoded = text.encode("utf-16-le") + b"\x00\x00"
-        h_mem = _GlobalAlloc(GMEM_MOVEABLE, len(encoded))
-        if not h_mem:
+        if not _EmptyClipboard():
             return False
-        ptr = _GlobalLock(h_mem)
-        if not ptr:
+        if not _set_clipboard_data_with_retries(CF_UNICODETEXT, h_mem):
             return False
-        ctypes.memmove(ptr, encoded, len(encoded))
-        _GlobalUnlock(h_mem)
-        _SetClipboardData(CF_UNICODETEXT, h_mem)
+        transferred = True  # Windows owns h_mem after this succeeds.
         return True
     finally:
         _CloseClipboard()
+        if not transferred:
+            _GlobalFree(h_mem)
+
+
+def _inject_via_clipboard(text: str) -> bool:
+    """Paste *text* and optionally restore the previous clipboard data."""
+    keep = getattr(config, "KEEP_TRANSCRIPT_IN_CLIPBOARD", False)
+    swap = None
+
+    try:
+        if keep:
+            ready = _set_clipboard_text(text)
+        else:
+            swap = _swap_clipboard_for_text(text)
+            ready = swap is not None
+        if not ready:
+            log.error("Failed to set clipboard text (already saved to recovery)")
+            return False
+        time.sleep(0.05)
+
+        with _keyboard.pressed(Key.ctrl):
+            _keyboard.press("v")
+            _keyboard.release("v")
+
+        # The synthesized Ctrl+V is queued; allow asynchronous UI frameworks
+        # time to consume the clipboard before restoring its original formats.
+        time.sleep(getattr(config, "CLIPBOARD_RESTORE_DELAY", 0.5))
+        return True
+    finally:
+        if swap is not None:
+            snapshot, sequence = swap
+            if not _restore_clipboard(snapshot, sequence, text):
+                log.warning("Original clipboard could not be restored")
 
 
 # ── Public API ────────────────────────────────────────────────────────────
@@ -131,8 +391,8 @@ def _save_recovery(text: str):
 
         from datetime import datetime
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        with open(RECOVERY_PATH, "a", encoding="utf-8") as f:
-            f.write(f"[{timestamp}] {text}\n")
+        with open(RECOVERY_PATH, "a", encoding="utf-8") as file:
+            file.write(f"[{timestamp}] {text}\n")
     except Exception as exc:
         log.error("Failed to save recovery text: %s", exc)
 
@@ -143,10 +403,9 @@ def inject(text: str):
     Every transcription is saved to recovery_notes.txt as a safety net,
     so dictated content is never lost even if the paste target ignores Ctrl+V.
 
-    By default the user's clipboard contents are captured before the paste
-    and restored afterwards. Setting ``config.KEEP_TRANSCRIPT_IN_CLIPBOARD``
-    to True skips the restore step so the transcribed text stays available
-    for re-pasting.
+    By default the user's supported clipboard contents are captured before the
+    paste and restored afterwards. Setting
+    ``config.KEEP_TRANSCRIPT_IN_CLIPBOARD`` to True skips the restore step.
     """
     if not text:
         return
@@ -154,20 +413,4 @@ def inject(text: str):
     # Always save to recovery file — paste target may silently ignore Ctrl+V
     _save_recovery(text)
 
-    keep = getattr(config, "KEEP_TRANSCRIPT_IN_CLIPBOARD", False)
-    original = None if keep else _get_clipboard_text()
-
-    try:
-        if not _set_clipboard_text(text):
-            log.error("Failed to set clipboard text (already saved to recovery)")
-            return
-        time.sleep(0.05)
-
-        with _keyboard.pressed(Key.ctrl):
-            _keyboard.press("v")
-            _keyboard.release("v")
-
-        time.sleep(0.10)
-    finally:
-        if not keep and original is not None:
-            _set_clipboard_text(original)
+    _inject_via_clipboard(text)

--- a/main.py
+++ b/main.py
@@ -55,6 +55,9 @@ settings_win = None
 scheduler   = None
 hotkey_listener = None
 
+_quit_requested = threading.Event()
+_shutting_down = False
+
 _rec_start  = 0.0
 _MIN_DURATION = 0.5
 _DELETE_CONFIRM_SECONDS = 15.0
@@ -523,7 +526,30 @@ def _show_settings():
         root.after(0, lambda: settings_win.show())
 
 
+def _request_quit():
+    """Receive a tray-thread request without calling Tk from that thread."""
+    _quit_requested.set()
+
+
+def _shutdown_requested() -> bool:
+    """Return True as soon as shutdown is requested or has begun."""
+    return _quit_requested.is_set() or _shutting_down
+
+
+def _poll_quit_request():
+    """Run shutdown on Tk's main thread when the tray requests it."""
+    if _quit_requested.is_set():
+        _quit()
+        return
+    if root:
+        root.after(50, _poll_quit_request)
+
+
 def _quit():
+    global _shutting_down
+    if _shutting_down:
+        return
+    _shutting_down = True
     log.info("Quitting...")
     _cancel_timeout("dictation")
     _cancel_timeout("assistant")
@@ -557,8 +583,7 @@ def _quit():
         try:
             root.after(50, _destroy_root)
         except Exception:
-            pass
-    log.info("Shutdown complete.")
+            _destroy_root()
 
 
 def _destroy_root():
@@ -567,6 +592,7 @@ def _destroy_root():
         root.destroy()
     except Exception:
         pass
+    log.info("Shutdown complete.")
 
 
 def _acquire_instance_lock():
@@ -633,14 +659,28 @@ def _finish_startup():
         )
         return  # tray stays alive so the user can read the toast and quit
 
+    if _shutdown_requested():
+        log.info("Startup cancelled after model load: shutdown requested.")
+        return
+
+    db.save_setting(model_flag, "1")
+
+    if _shutdown_requested():
+        return
     scheduler = ReminderScheduler()
     scheduler.start()
 
+    if _shutdown_requested():
+        scheduler.stop()
+        scheduler = None
+        return
     t1 = threading.Thread(target=_dictation_worker, daemon=True)
     t1.start()
     t2 = threading.Thread(target=_assistant_worker, daemon=True)
     t2.start()
 
+    if _shutdown_requested():
+        return
     hotkey_listener = HotkeyListener(
         on_press_cb=_on_hotkey_press,
         on_release_cb=_on_hotkey_release,
@@ -649,6 +689,10 @@ def _finish_startup():
     )
     hotkey_listener.start()
 
+    if _shutdown_requested():
+        hotkey_listener.stop()
+        hotkey_listener = None
+        return
     dict_key = key_display_name(config.HOTKEY)
     # Wording must match the configured recording mode: "hold" is wrong
     # (and misleading) when the user has toggle mode enabled.
@@ -690,13 +734,14 @@ def main():
     recorder.on_level = lambda rms: widget.update_level(min(1.0, rms * 8))
     recorder.on_mic_error = lambda msg: widget.show_message(msg, 4000)
 
-    tray = TrayIcon(on_quit=_quit, on_show_notes=_show_notes,
+    tray = TrayIcon(on_quit=_request_quit, on_show_notes=_show_notes,
                     on_show_settings=_show_settings)
     tray.start()
     tray.set_tooltip(locales.get("tray_idle"))
 
     threading.Thread(target=_finish_startup, daemon=True).start()
 
+    root.after(50, _poll_quit_request)
     root.mainloop()
 
     # Belt and braces: pystray's run_detached() thread is non-daemon and can

--- a/notifier.py
+++ b/notifier.py
@@ -2,7 +2,6 @@
 
 import subprocess
 import threading
-import time
 from datetime import datetime
 from logger import log
 import config
@@ -105,6 +104,8 @@ class ReminderScheduler:
 
     def stop(self):
         self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
 
     def _loop(self):
         while not self._stop.is_set():

--- a/test_injector.py
+++ b/test_injector.py
@@ -1,0 +1,186 @@
+import unittest
+from unittest.mock import call, patch
+
+import config
+import injector
+
+
+class TestInjection(unittest.TestCase):
+    @patch.object(injector, "_inject_via_clipboard", return_value=True)
+    @patch.object(injector, "_save_recovery")
+    def test_saves_recovery_then_uses_clipboard_paste(
+            self, save_recovery, clipboard_paste):
+        injector.inject("hello")
+
+        save_recovery.assert_called_once_with("hello")
+        clipboard_paste.assert_called_once_with("hello")
+
+
+class TestClipboardPaste(unittest.TestCase):
+    def setUp(self):
+        self.original_keep = config.KEEP_TRANSCRIPT_IN_CLIPBOARD
+        self.original_delay = config.CLIPBOARD_RESTORE_DELAY
+
+    def tearDown(self):
+        config.KEEP_TRANSCRIPT_IN_CLIPBOARD = self.original_keep
+        config.CLIPBOARD_RESTORE_DELAY = self.original_delay
+
+    @patch.object(injector, "_keyboard")
+    @patch.object(injector.time, "sleep")
+    @patch.object(injector, "_restore_clipboard", return_value=True)
+    @patch.object(injector, "_swap_clipboard_for_text",
+                  return_value=([(8, 200)], 42))
+    def test_restores_all_original_formats_after_paste(
+            self, swap, restore, sleep, keyboard):
+        config.KEEP_TRANSCRIPT_IN_CLIPBOARD = False
+        config.CLIPBOARD_RESTORE_DELAY = 0.75
+
+        self.assertTrue(injector._inject_via_clipboard("hello"))
+
+        swap.assert_called_once_with("hello")
+        restore.assert_called_once_with([(8, 200)], 42, "hello")
+        keyboard.press.assert_called_once_with("v")
+        keyboard.release.assert_called_once_with("v")
+        self.assertEqual(
+            sleep.call_args_list,
+            [call(0.05), call(0.75)],
+        )
+
+    @patch.object(injector, "_keyboard")
+    @patch.object(injector.time, "sleep")
+    @patch.object(injector, "_set_clipboard_text", return_value=True)
+    def test_retention_leaves_transcript_in_clipboard(
+            self, set_clipboard, _sleep, _keyboard):
+        config.KEEP_TRANSCRIPT_IN_CLIPBOARD = True
+
+        self.assertTrue(injector._inject_via_clipboard("hello"))
+
+        set_clipboard.assert_called_once_with("hello")
+
+
+class TestClipboardPreservation(unittest.TestCase):
+    @patch.object(injector, "_duplicate_clipboard_handle",
+                  side_effect=[201, 202])
+    @patch.object(injector, "_GetClipboardData", side_effect=[101, 102])
+    @patch.object(injector, "_EnumClipboardFormats",
+                  side_effect=[injector.CF_UNICODETEXT, 8, 0])
+    def test_capture_duplicates_every_enumerated_format(
+            self, _enum_formats, _get_data, duplicate):
+        snapshot = injector._capture_open_clipboard()
+
+        self.assertEqual(
+            snapshot,
+            [(injector.CF_UNICODETEXT, 201), (8, 202)],
+        )
+        self.assertEqual(
+            [call.args for call in duplicate.call_args_list],
+            [(injector.CF_UNICODETEXT, 101), (8, 102)],
+        )
+
+    @patch.object(injector, "_free_clipboard_snapshot")
+    @patch.object(injector, "_duplicate_clipboard_handle",
+                  side_effect=[201, None])
+    @patch.object(injector, "_GetClipboardData", side_effect=[101, 102])
+    @patch.object(injector, "_EnumClipboardFormats", side_effect=[13, 8])
+    def test_capture_failure_releases_duplicates_without_emptying_clipboard(
+            self, _enum_formats, _get_data, _duplicate, free_snapshot):
+        self.assertIsNone(injector._capture_open_clipboard())
+
+        free_snapshot.assert_called_once_with([(13, 201)])
+
+    @patch.object(injector, "_CloseClipboard")
+    @patch.object(injector, "_GetClipboardSequenceNumber", return_value=77)
+    @patch.object(injector, "_SetClipboardData", return_value=300)
+    @patch.object(injector, "_EmptyClipboard", return_value=True)
+    @patch.object(injector, "_capture_open_clipboard",
+                  return_value=[(8, 201)])
+    @patch.object(injector, "_open_clipboard", return_value=True)
+    @patch.object(injector, "_allocate_clipboard_text", return_value=300)
+    def test_swap_backs_up_and_replaces_while_clipboard_stays_open(
+            self, _allocate, _open, _capture, empty, set_data,
+            _sequence, close):
+        self.assertEqual(
+            injector._swap_clipboard_for_text("hello"),
+            ([(8, 201)], 77),
+        )
+
+        empty.assert_called_once_with()
+        set_data.assert_called_once_with(injector.CF_UNICODETEXT, 300)
+        close.assert_called_once_with()
+
+    @patch.object(injector, "_free_clipboard_snapshot")
+    @patch.object(injector, "_CloseClipboard")
+    @patch.object(injector, "_EmptyClipboard")
+    @patch.object(injector, "_GetClipboardSequenceNumber", return_value=78)
+    @patch.object(injector, "_open_clipboard", return_value=True)
+    def test_restore_does_not_overwrite_a_new_user_copy(
+            self, _open, _sequence, empty, _close, free_snapshot):
+        snapshot = [(8, 201), (13, 202)]
+
+        self.assertFalse(injector._restore_clipboard(snapshot, 77))
+
+        empty.assert_not_called()
+        free_snapshot.assert_called_once_with(snapshot)
+
+    @patch.object(injector, "_free_clipboard_snapshot")
+    @patch.object(injector, "_CloseClipboard")
+    @patch.object(injector, "_EmptyClipboard")
+    @patch.object(injector, "_open_clipboard_text", return_value="new copy")
+    @patch.object(injector, "_GetClipboardSequenceNumber", return_value=77)
+    @patch.object(injector, "_open_clipboard", return_value=True)
+    def test_restore_checks_temporary_text_as_well_as_sequence(
+            self, _open, _sequence, _text, empty, _close, free_snapshot):
+        snapshot = [(13, 201)]
+
+        self.assertFalse(
+            injector._restore_clipboard(snapshot, 77, "transcript"))
+
+        empty.assert_not_called()
+        free_snapshot.assert_called_once_with(snapshot)
+
+    @patch.object(injector, "_free_clipboard_snapshot")
+    @patch.object(injector, "_CloseClipboard")
+    @patch.object(injector, "_SetClipboardData", return_value=1)
+    @patch.object(injector, "_EmptyClipboard", return_value=True)
+    @patch.object(injector, "_GetClipboardSequenceNumber", return_value=77)
+    @patch.object(injector, "_open_clipboard", return_value=True)
+    def test_restore_transfers_every_format_in_original_order(
+            self, _open, _sequence, _empty, set_data, _close,
+            free_snapshot):
+        snapshot = [(8, 201), (13, 202)]
+
+        self.assertTrue(injector._restore_clipboard(snapshot, 77))
+
+        self.assertEqual(
+            [call.args for call in set_data.call_args_list],
+            [(8, 201), (13, 202)],
+        )
+        free_snapshot.assert_called_once_with([])
+
+    @patch.object(injector.time, "sleep")
+    @patch.object(injector, "_free_clipboard_handle")
+    @patch.object(injector, "_free_clipboard_snapshot")
+    @patch.object(injector, "_CloseClipboard")
+    @patch.object(injector, "_SetClipboardData",
+                  side_effect=[1, 0, 0, 0, 1])
+    @patch.object(injector, "_EmptyClipboard", return_value=True)
+    @patch.object(injector, "_GetClipboardSequenceNumber", return_value=77)
+    @patch.object(injector, "_open_clipboard", return_value=True)
+    def test_restore_retries_failure_and_continues_with_later_formats(
+            self, _open, _sequence, _empty, set_data, _close,
+            free_snapshot, free_handle, sleep):
+        snapshot = [(8, 201), (9, 202), (13, 203)]
+
+        self.assertFalse(injector._restore_clipboard(snapshot, 77))
+
+        self.assertEqual(
+            [item.args for item in set_data.call_args_list],
+            [(8, 201), (9, 202), (9, 202), (9, 202), (13, 203)],
+        )
+        self.assertEqual(sleep.call_count, 2)
+        free_handle.assert_called_once_with(9, 202)
+        free_snapshot.assert_called_once_with([])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_shutdown.py
+++ b/test_shutdown.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import main
+
+
+class TestStartupShutdownRace(unittest.TestCase):
+    def tearDown(self):
+        main._quit_requested.clear()
+        main._shutting_down = False
+        main.transcriber = None
+        main.scheduler = None
+        main.hotkey_listener = None
+
+    def test_services_do_not_start_when_quit_arrives_during_model_load(self):
+        def finish_model_load():
+            main._quit_requested.set()
+            return Mock()
+
+        with (
+            patch.object(main, "widget", Mock()),
+            patch.object(main.db, "get_setting", return_value="1"),
+            patch.object(main.db, "save_setting") as save_setting,
+            patch.object(main, "Transcriber",
+                         side_effect=finish_model_load),
+            patch.object(main, "ReminderScheduler") as reminder_scheduler,
+            patch.object(main, "HotkeyListener") as hotkey_listener,
+        ):
+            main._finish_startup()
+
+        save_setting.assert_not_called()
+        reminder_scheduler.assert_not_called()
+        hotkey_listener.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_tray_icon.py
+++ b/test_tray_icon.py
@@ -1,0 +1,28 @@
+import threading
+import unittest
+from unittest.mock import patch
+
+import tray_icon
+
+
+class TestTrayShutdown(unittest.TestCase):
+    @patch.object(tray_icon, "make_tray_icon")
+    @patch.object(tray_icon.pystray, "Icon")
+    def test_stop_joins_the_daemon_tray_thread(self, icon_class, _image):
+        release = threading.Event()
+        native_icon = icon_class.return_value
+        native_icon.run.side_effect = release.wait
+        native_icon.stop.side_effect = release.set
+        tray = tray_icon.TrayIcon(on_quit=lambda: None)
+
+        tray.start()
+        self.assertTrue(tray._thread.daemon)
+
+        tray.stop()
+
+        native_icon.stop.assert_called_once_with()
+        self.assertFalse(tray._thread.is_alive())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tray_icon.py
+++ b/tray_icon.py
@@ -1,5 +1,7 @@
 """System tray icon for Writher with Pandora Blackboard eyes."""
 
+import threading
+
 import pystray
 import locales
 from brand import make_tray_icon
@@ -11,6 +13,7 @@ class TrayIcon:
         self._on_show_notes = on_show_notes
         self._on_show_settings = on_show_settings
         self._icon = None
+        self._thread = None
 
     def _build_menu(self):
         items = [
@@ -48,7 +51,13 @@ class TrayIcon:
             locales.get("tray_idle"),
             menu=self._build_menu(),
         )
-        self._icon.run_detached()
+        # Track the tray thread so shutdown can wait for it.
+        self._thread = threading.Thread(
+            target=self._icon.run,
+            name="WritHerTray",
+            daemon=True,
+        )
+        self._thread.start()
 
     def set_recording(self, recording: bool):
         if self._icon is None:
@@ -65,3 +74,6 @@ class TrayIcon:
     def stop(self):
         if self._icon is not None:
             self._icon.stop()
+        if (self._thread is not None
+                and self._thread is not threading.current_thread()):
+            self._thread.join(timeout=2.0)


### PR DESCRIPTION
## What changed

- preserve safely duplicable Windows clipboard formats during dictation paste, including common image and copied-file formats
- restore the clipboard only when WritHer’s temporary transcript is still present
- retry clipboard transfers and avoid overwriting clipboard content copied during the paste
- make the clipboard restoration delay configurable
- run tray-triggered shutdown on Tk’s main thread and join tray, hotkey, and reminder threads
- cancel service startup when shutdown is requested while the Whisper model is loading

## Why

WritHer previously backed up only Unicode text, so pasting dictated text could destroy screenshots, copied files, and other non-text clipboard formats. Its tray callback could also log `Shutdown complete` while the Tk or tray event loop still kept Python alive.

## Impact

Dictation keeps the compatible Ctrl+V workflow while preserving common clipboard content. Quitting from the tray now terminates the process deterministically, including during startup.

## Validation

- 54 tests pass on current upstream `main`
- focused Ruff checks pass
- compilation checks pass
- `git diff --check` passes
- native Windows tray + Tk lifecycle test exits cleanly
- native CF_DIB and CF_HDROP preservation checks passed during development