### PR TITLE
Recording safety cap + runtime GPU settings + optional audio cues (fixes #25, #23, #24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ site/
 build/
 dist/
 
+# Release packages (kept local only)
+WritHer-*.zip
+*.zip
+
 # SEO instructions (local only)
 modificaseo.md
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 ## 🆕 What's New
 
 - 🎚️ **GPU settings without editing code** - **Compute device** (CPU / CUDA) and **precision** (int8 / float16 / float32) are now selectable from Settings and persisted, so packaged-exe users can enable CUDA without touching `config.py`. Takes effect after a restart. (requested by [@MaxiKingXXL](https://github.com/MaxiKingXXL))
+- 🔊 **Recording sound cues (opt-in)** - enable in Settings to hear a short high tone when dictation starts and a low tone when it stops - eyes-free confirmation and a pacing cue so you don't clip the start of your speech. Tones are generated in memory and played non-blocking; dictation is never delayed or broken if audio playback fails. (requested by [@MaxiKingXXL](https://github.com/MaxiKingXXL))
 - 🛡️ **Hold-mode recording safety cap** - if a key-release event is ever lost, hold-to-record could previously leave the microphone recording indefinitely. `MAX_RECORD_SECONDS` now caps *both* recording modes; when the cap is hit in hold mode the mic stops and the audio is discarded (never pasted), and the shared recorder now tracks a single session owner so audio can't leak from one mode into another. (root-caused by [@MaxiKingXXL](https://github.com/MaxiKingXXL))
 - 🤖 **OpenAI-compatible providers** - the assistant now works with llama.cpp, LM Studio and any OpenAI-compatible local server, not just Ollama. Pick the provider in Settings; models are discovered automatically via `/v1/models`, and each provider keeps its own URL and model settings. (thanks [@aladin7](https://github.com/aladin7))
 - 🖼️ **Clipboard keeps your images and files** - dictating no longer destroys non-text clipboard content: screenshots, copied files and other formats are preserved and restored after the paste. If you copy something new while WritHer is pasting, your fresh copy wins. Restore delay is configurable via `CLIPBOARD_RESTORE_DELAY`. (thanks [@aladin7](https://github.com/aladin7))
@@ -251,6 +252,9 @@ MODEL_SIZE = "small"           # tiny, base, small (default), medium, large-v3
 DEVICE = "cpu"                 # "cpu" or "cuda"  (also selectable in Settings)
 COMPUTE_TYPE = "int8"          # int8, float16, float32  (also in Settings)
 
+# Recording audio cues (Windows) - high tone on start, low tone on stop.
+AUDIO_CUES = False             # opt-in; toggle from Settings
+
 # Assistant provider: "ollama" or "openai"
 ASSISTANT_PROVIDER = "ollama"
 
@@ -267,7 +271,7 @@ OPENAI_API_KEY = ""             # Optional; leave empty for local servers
 APPOINTMENT_REMIND_MINUTES = 15
 ```
 
-> **Note:** Recording, microphone, hotkey, assistant provider, assistant model, assistant URL, and compute device/precision settings can also be changed at runtime from the **Settings** window in the system tray. Changes made there are persisted in the database and override `config.py` defaults. (Whisper model and compute device/precision changes take effect after a restart.)
+> **Note:** Recording, microphone, hotkey, assistant provider, assistant model, assistant URL, compute device/precision, and audio-cue settings can also be changed at runtime from the **Settings** window in the system tray. Changes made there are persisted in the database and override `config.py` defaults. (Whisper model and compute device/precision changes take effect after a restart.)
 
 ### Choosing a Whisper model
 
@@ -398,6 +402,7 @@ writher/
 ├── recorder.py          # Microphone recording (sounddevice)
 ├── transcriber.py       # Speech-to-text (faster-whisper)
 ├── replacements.py      # Two-layer post-processing (user vocab + opt-in symbols)
+├── audio_cues.py        # Optional start/stop dictation tones (winsound)
 ├── injector.py          # Clipboard paste into active app (Win32 API)
 ├── assistant.py         # Local LLM provider integration + function calling
 ├── database.py          # SQLite storage (notes, appointments, reminders, settings)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 ## 🆕 What's New
 
+- 🛡️ **Hold-mode recording safety cap** - if a key-release event is ever lost, hold-to-record could previously leave the microphone recording indefinitely. `MAX_RECORD_SECONDS` now caps *both* recording modes; when the cap is hit in hold mode the mic stops and the audio is discarded (never pasted), and the shared recorder now tracks a single session owner so audio can't leak from one mode into another. (root-caused by [@MaxiKingXXL](https://github.com/MaxiKingXXL))
 - 🤖 **OpenAI-compatible providers** - the assistant now works with llama.cpp, LM Studio and any OpenAI-compatible local server, not just Ollama. Pick the provider in Settings; models are discovered automatically via `/v1/models`, and each provider keeps its own URL and model settings. (thanks [@aladin7](https://github.com/aladin7))
 - 🖼️ **Clipboard keeps your images and files** - dictating no longer destroys non-text clipboard content: screenshots, copied files and other formats are preserved and restored after the paste. If you copy something new while WritHer is pasting, your fresh copy wins. Restore delay is configurable via `CLIPBOARD_RESTORE_DELAY`. (thanks [@aladin7](https://github.com/aladin7))
 - 👻 **Quit really quits** - closing WritHer from the tray now always terminates the process. No more invisible ghost instance holding the single-instance lock and blocking the next launch.
@@ -52,7 +53,7 @@
 - ⌨️ **Customizable hotkeys** - change dictation and assistant shortcuts from Settings. Press the ⌨ button, hit any key, done. No restart needed.
 - 🎙️ **Microphone selection** - pick your input device from Settings, with hot-plug refresh
 - 🔄 **Toggle recording mode** - press once to start, press again to stop (alternative to hold)
-- ⏱️ **Safety timeout** - auto-stops recording in toggle mode if you forget
+- ⏱️ **Safety timeout** - caps recording length in both modes: auto-stops toggle mode if you forget, and bounds hold mode if a key-release is lost
 - 🎨 **Redesigned UI** - CustomTkinter with unified Pandora Blackboard theme (pure black + bright white)
 - 🖥️ **Resizable Notes window** - drag to resize, maximize/restore, DPI-aware
 - ⚡ **Faster Ollama responses** - timeout increased from 10s to 30s for larger models

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 ## 🆕 What's New
 
+- 🎚️ **GPU settings without editing code** - **Compute device** (CPU / CUDA) and **precision** (int8 / float16 / float32) are now selectable from Settings and persisted, so packaged-exe users can enable CUDA without touching `config.py`. Takes effect after a restart. (requested by [@MaxiKingXXL](https://github.com/MaxiKingXXL))
 - 🛡️ **Hold-mode recording safety cap** - if a key-release event is ever lost, hold-to-record could previously leave the microphone recording indefinitely. `MAX_RECORD_SECONDS` now caps *both* recording modes; when the cap is hit in hold mode the mic stops and the audio is discarded (never pasted), and the shared recorder now tracks a single session owner so audio can't leak from one mode into another. (root-caused by [@MaxiKingXXL](https://github.com/MaxiKingXXL))
 - 🤖 **OpenAI-compatible providers** - the assistant now works with llama.cpp, LM Studio and any OpenAI-compatible local server, not just Ollama. Pick the provider in Settings; models are discovered automatically via `/v1/models`, and each provider keeps its own URL and model settings. (thanks [@aladin7](https://github.com/aladin7))
 - 🖼️ **Clipboard keeps your images and files** - dictating no longer destroys non-text clipboard content: screenshots, copied files and other formats are preserved and restored after the paste. If you copy something new while WritHer is pasting, your fresh copy wins. Restore delay is configurable via `CLIPBOARD_RESTORE_DELAY`. (thanks [@aladin7](https://github.com/aladin7))
@@ -247,8 +248,8 @@ MIC_DEVICE_NAME = None         # None = system default, or device name (str)
 
 # Whisper
 MODEL_SIZE = "small"           # tiny, base, small (default), medium, large-v3
-DEVICE = "cpu"                 # "cpu" or "cuda"
-COMPUTE_TYPE = "int8"          # int8, float16, float32
+DEVICE = "cpu"                 # "cpu" or "cuda"  (also selectable in Settings)
+COMPUTE_TYPE = "int8"          # int8, float16, float32  (also in Settings)
 
 # Assistant provider: "ollama" or "openai"
 ASSISTANT_PROVIDER = "ollama"
@@ -266,7 +267,7 @@ OPENAI_API_KEY = ""             # Optional; leave empty for local servers
 APPOINTMENT_REMIND_MINUTES = 15
 ```
 
-> **Note:** Recording, microphone, hotkey, assistant provider, assistant model, and assistant URL settings can also be changed at runtime from the **Settings** window in the system tray. Changes made there are persisted in the database and override `config.py` defaults.
+> **Note:** Recording, microphone, hotkey, assistant provider, assistant model, assistant URL, and compute device/precision settings can also be changed at runtime from the **Settings** window in the system tray. Changes made there are persisted in the database and override `config.py` defaults. (Whisper model and compute device/precision changes take effect after a restart.)
 
 ### Choosing a Whisper model
 

--- a/audio_cues.py
+++ b/audio_cues.py
@@ -1,0 +1,77 @@
+"""Optional short audio cues for dictation recording start/stop (issue #24).
+
+Off by default; enabled via the persisted ``audio_cues`` setting. The tones are
+generated as PCM WAV in memory and played with
+``winsound.PlaySound(SND_MEMORY | SND_ASYNC)`` on a daemon thread, so playback
+never blocks the hotkey callback or delays recording. SND_MEMORY playback
+proved more reliable than ``winsound.Beep`` when the default audio device
+changes. Any playback failure is logged at debug level and swallowed — a
+missing or busy audio device must never break dictation.
+"""
+
+import io
+import math
+import struct
+import sys
+import threading
+import wave
+
+from logger import log
+
+_SAMPLE_RATE = 44100
+_START_FREQ = 880.0   # A5 — higher tone: recording started
+_STOP_FREQ = 440.0    # A4 — lower tone: recording stopped
+_DURATION = 0.12      # seconds
+_VOLUME = 0.35        # 0.0 .. 1.0
+
+# Rendered WAV bytes are cached: the two tones never change, and the SND_ASYNC
+# playback needs the buffer to stay alive for the duration of the sound.
+_cache: dict[float, bytes] = {}
+
+
+def _render_tone(freq: float) -> bytes:
+    """Return a mono 16-bit PCM WAV of a short, fading sine wave at *freq*."""
+    cached = _cache.get(freq)
+    if cached is not None:
+        return cached
+    n = int(_SAMPLE_RATE * _DURATION)
+    frames = bytearray()
+    for i in range(n):
+        # Linear fade-out avoids an audible click at the end of the tone.
+        fade = 1.0 - (i / n)
+        sample = _VOLUME * fade * math.sin(2.0 * math.pi * freq * i / _SAMPLE_RATE)
+        frames += struct.pack("<h", int(sample * 32767))
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(_SAMPLE_RATE)
+        wav.writeframes(bytes(frames))
+    data = buf.getvalue()
+    _cache[freq] = data
+    return data
+
+
+def _play(freq: float):
+    try:
+        import winsound
+        winsound.PlaySound(
+            _render_tone(freq), winsound.SND_MEMORY | winsound.SND_ASYNC)
+    except Exception as exc:
+        log.debug("Audio cue playback failed: %s", exc)
+
+
+def _play_async(freq: float):
+    if sys.platform != "win32":
+        return
+    threading.Thread(target=_play, args=(freq,), daemon=True).start()
+
+
+def play_start():
+    """Play the 'recording started' cue (higher tone)."""
+    _play_async(_START_FREQ)
+
+
+def play_stop():
+    """Play the 'recording stopped' cue (lower tone)."""
+    _play_async(_STOP_FREQ)

--- a/config.py
+++ b/config.py
@@ -52,7 +52,9 @@ CLIPBOARD_RESTORE_DELAY = 0.5
 # True = hold key to record (release stops).  False = toggle (press start, press stop).
 HOLD_TO_RECORD = True
 
-# Maximum recording duration in seconds (toggle mode only, safety net).
+# Maximum recording duration in seconds. Safety cap for both recording modes:
+# in toggle mode it auto-stops if you forget to press again; in hold mode it
+# bounds the mic if a key-release event is ever lost (issue #25). 0 disables.
 MAX_RECORD_SECONDS = 120
 
 # ── Appointment notifications ─────────────────────────────────────────────

--- a/config.py
+++ b/config.py
@@ -60,6 +60,11 @@ HOLD_TO_RECORD = True
 # bounds the mic if a key-release event is ever lost (issue #25). 0 disables.
 MAX_RECORD_SECONDS = 120
 
+# Play a short high tone when dictation recording starts and a low tone when it
+# stops (eyes-free confirmation / pacing cue). Off by default; toggle from
+# Settings. Windows only. (issue #24)
+AUDIO_CUES = False
+
 # ── Appointment notifications ─────────────────────────────────────────────
 # How many minutes before an appointment to send a toast notification.
 APPOINTMENT_REMIND_MINUTES = 15

--- a/config.py
+++ b/config.py
@@ -22,6 +22,9 @@ WHISPER_LANGUAGE = None
 
 MODEL_SIZE = "base"
 SAMPLE_RATE = 16000
+# Inference device / precision. Also selectable at runtime from Settings and
+# persisted in the DB (issue #23). DEVICE: "cpu" or "cuda" (needs the NVIDIA
+# CUDA/cuDNN runtime). COMPUTE_TYPE: "int8", "float16" or "float32".
 DEVICE = "cpu"
 COMPUTE_TYPE = "int8"
 

--- a/hotkey.py
+++ b/hotkey.py
@@ -167,6 +167,26 @@ class HotkeyListener:
             if self._on_assist_release:
                 self._safe_call(self._on_assist_release, "Assistant timeout-stop")
 
+    def reset_dictation_state(self):
+        """Clear dictation press/record flags without firing any callback.
+
+        Used by the hold-mode safety timeout: when a key-release event is lost
+        the ``_dict_pressed`` flag stays stuck True, which would silently
+        swallow the next press and wedge the hotkey. Resetting it lets the
+        hotkey recover after the mic has been force-stopped (issue #25).
+        """
+        self._dict_pressed = False
+        self._dict_recording = False
+
+    def reset_assistant_state(self):
+        """Clear assistant press/record flags without firing any callback.
+
+        Hold-mode safety-timeout counterpart to reset_dictation_state()
+        (issue #25).
+        """
+        self._assist_pressed = False
+        self._assist_recording = False
+
     # ── helpers ───────────────────────────────────────────────────────────
 
     @staticmethod

--- a/locales.py
+++ b/locales.py
@@ -167,6 +167,9 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "setting_vocab_empty":      "No entries yet",
         "setting_priming":          "Priming terms (best-effort)",
         "setting_priming_hint":     "Comma-separated hints joined into faster-whisper's initial prompt. Best-effort.",
+        "setting_device":           "Compute device",
+        "setting_compute_type":     "Compute precision",
+        "setting_device_hint":      "CUDA needs an NVIDIA GPU with the CUDA/cuDNN runtime. Wrong settings fall back to CPU. Restart required to apply.",
     },
 
     "it": {
@@ -314,6 +317,9 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "setting_vocab_empty":      "Nessuna voce",
         "setting_priming":          "Termini di priming (best-effort)",
         "setting_priming_hint":     "Suggerimenti separati da virgola inseriti nell'initial prompt di faster-whisper. Best-effort.",
+        "setting_device":           "Dispositivo di calcolo",
+        "setting_compute_type":     "Precisione di calcolo",
+        "setting_device_hint":      "CUDA richiede una GPU NVIDIA con runtime CUDA/cuDNN. Impostazioni errate tornano alla CPU. Riavvio necessario per applicare.",
     },
 
     "de": {
@@ -456,6 +462,9 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "setting_vocab_empty":      "Noch keine Einträge",
         "setting_priming":          "Priming-Begriffe (best-effort)",
         "setting_priming_hint":     "Komma-getrennte Hinweise für faster-whispers initial_prompt. Best-effort.",
+        "setting_device":           "Recheneinheit",
+        "setting_compute_type":     "Rechenpräzision",
+        "setting_device_hint":      "CUDA erfordert eine NVIDIA-GPU mit CUDA/cuDNN-Runtime. Falsche Einstellungen fallen auf die CPU zurück. Neustart erforderlich.",
     },
 }
 

--- a/locales.py
+++ b/locales.py
@@ -170,6 +170,8 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "setting_device":           "Compute device",
         "setting_compute_type":     "Compute precision",
         "setting_device_hint":      "CUDA needs an NVIDIA GPU with the CUDA/cuDNN runtime. Wrong settings fall back to CPU. Restart required to apply.",
+        "setting_audio_cues":       "Recording sound cues",
+        "setting_audio_cues_hint":  "Play a short high tone when dictation starts and a low tone when it stops (dictation only).",
     },
 
     "it": {
@@ -320,6 +322,8 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "setting_device":           "Dispositivo di calcolo",
         "setting_compute_type":     "Precisione di calcolo",
         "setting_device_hint":      "CUDA richiede una GPU NVIDIA con runtime CUDA/cuDNN. Impostazioni errate tornano alla CPU. Riavvio necessario per applicare.",
+        "setting_audio_cues":       "Suoni di registrazione",
+        "setting_audio_cues_hint":  "Riproduce un tono alto quando la dettatura inizia e un tono basso quando finisce (solo dettatura).",
     },
 
     "de": {
@@ -465,6 +469,8 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "setting_device":           "Recheneinheit",
         "setting_compute_type":     "Rechenpräzision",
         "setting_device_hint":      "CUDA erfordert eine NVIDIA-GPU mit CUDA/cuDNN-Runtime. Falsche Einstellungen fallen auf die CPU zurück. Neustart erforderlich.",
+        "setting_audio_cues":       "Aufnahme-Signaltöne",
+        "setting_audio_cues_hint":  "Spielt einen hohen Ton bei Aufnahmestart und einen tiefen Ton beim Stopp (nur Diktat).",
     },
 }
 

--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ from notifier import ReminderScheduler
 from notes_window import NotesWindow
 from settings_window import SettingsWindow
 from replacements import apply_replacements
+import audio_cues
 
 _pipeline_queue   = queue.Queue()
 _assistant_queue  = queue.Queue()
@@ -122,6 +123,9 @@ def _load_settings():
     compute_type = db.get_setting("compute_type", "")
     if compute_type in {"int8", "float16", "float32"}:
         config.COMPUTE_TYPE = compute_type
+    audio_cues_setting = db.get_setting("audio_cues", "")
+    if audio_cues_setting != "":
+        config.AUDIO_CUES = audio_cues_setting == "1"
     lang = db.get_setting("language", "")
     if lang:
         config.LANGUAGE = lang
@@ -245,6 +249,10 @@ def _safety_stop(mode: str):
                 hotkey_listener.reset_dictation_state()
             else:
                 hotkey_listener.reset_assistant_state()
+        # Toggle mode announces the stop via the normal release path below;
+        # the hold-mode discard path has to play the cue itself (dictation only).
+        if mode == "dictation" and config.AUDIO_CUES:
+            audio_cues.play_stop()
         if tray:
             tray.set_recording(False)
         if widget:
@@ -277,6 +285,8 @@ def _timeout_assistant(generation: int):
 
 def _on_hotkey_press():
     _begin_recording("dictation")
+    if config.AUDIO_CUES:
+        audio_cues.play_start()
     if tray:
         tray.set_recording(True)
     if widget:
@@ -286,6 +296,8 @@ def _on_hotkey_press():
 
 def _on_hotkey_release():
     audio = _end_recording("dictation")
+    if config.AUDIO_CUES:
+        audio_cues.play_stop()
     duration = time.monotonic() - _rec_start
     if tray:
         tray.set_recording(False)

--- a/main.py
+++ b/main.py
@@ -64,9 +64,17 @@ _DELETE_CONFIRM_SECONDS = 15.0
 _DELETE_CONFIRM_TOKEN = re.compile(r"^__confirm_delete__:(note|appointment|reminder):(\d+)$")
 _pending_delete = None
 
-# Toggle-mode timeout timers
+# Safety-timeout timers (both hold and toggle modes)
 _dict_timeout_timer  = None
 _assist_timeout_timer = None
+
+# Recorder ownership. The dictation and assistant pipelines share a single
+# Recorder instance; these track who currently owns it so a lost key-release,
+# a stale timeout, or an overlapping press can't leak audio from one session
+# into another (issue #25).
+_rec_lock       = threading.Lock()
+_active_mode    = None   # None | "dictation" | "assistant"
+_rec_generation = 0      # bumped on every start; lets stale timers self-cancel
 
 
 # ── Load persisted settings into config at startup ────────────────────────
@@ -128,22 +136,27 @@ def _load_settings():
             config.ASSISTANT_HOTKEY = parsed
 
 
-# ── Toggle-mode timeout helpers ───────────────────────────────────────────
+# ── Recording session ownership & safety timeout ──────────────────────────
 
-def _start_timeout(mode: str):
-    """Start a safety timer that auto-stops recording in toggle mode."""
+def _start_timeout(mode: str, generation: int):
+    """Arm a safety timer that hard-caps recording length.
+
+    Runs in BOTH hold and toggle modes. In hold mode a missed key-release
+    event would otherwise leave the mic recording until another code path
+    stops it or the process exits (issue #25); the cap bounds that window.
+    """
     global _dict_timeout_timer, _assist_timeout_timer
-    if config.HOLD_TO_RECORD:
-        return
     seconds = getattr(config, "MAX_RECORD_SECONDS", 120)
     if seconds <= 0:
         return
     if mode == "dictation":
-        _dict_timeout_timer = threading.Timer(seconds, _timeout_dictation)
+        _dict_timeout_timer = threading.Timer(
+            seconds, _timeout_dictation, args=(generation,))
         _dict_timeout_timer.daemon = True
         _dict_timeout_timer.start()
     elif mode == "assistant":
-        _assist_timeout_timer = threading.Timer(seconds, _timeout_assistant)
+        _assist_timeout_timer = threading.Timer(
+            seconds, _timeout_assistant, args=(generation,))
         _assist_timeout_timer.daemon = True
         _assist_timeout_timer.start()
 
@@ -158,35 +171,115 @@ def _cancel_timeout(mode: str):
         _assist_timeout_timer = None
 
 
-def _timeout_dictation():
-    log.warning("Toggle-mode dictation timeout reached.")
-    if hotkey_listener:
-        hotkey_listener.force_stop_dictation()
+def _begin_recording(mode: str) -> int:
+    """Take ownership of the shared recorder for *mode* and start capturing.
+
+    Returns the new recording generation. If the recorder is still owned by an
+    earlier session — e.g. a lost key-release left it running — that session is
+    stopped, its buffer discarded, and its hotkey state reset before the new
+    one starts, so audio can never leak across sessions or modes (issue #25).
+    """
+    global _active_mode, _rec_generation, _rec_start
+    with _rec_lock:
+        if _active_mode is not None:
+            stale = _active_mode
+            log.warning("Recorder still owned by %s when %s started — "
+                        "discarding stale session.", stale, mode)
+            _cancel_timeout(stale)
+            try:
+                recorder.stop()  # drop the inherited buffer
+            except Exception as exc:
+                log.error("Failed to discard stale recording: %s", exc)
+            if hotkey_listener:
+                if stale == "dictation":
+                    hotkey_listener.reset_dictation_state()
+                else:
+                    hotkey_listener.reset_assistant_state()
+        _rec_generation += 1
+        generation = _rec_generation
+        _active_mode = mode
+        _rec_start = time.monotonic()
+        recorder.start()
+        _start_timeout(mode, generation)
+        return generation
 
 
-def _timeout_assistant():
-    log.warning("Toggle-mode assistant timeout reached.")
-    if hotkey_listener:
-        hotkey_listener.force_stop_assistant()
+def _end_recording(mode: str, discard: bool = False):
+    """Release ownership of the recorder and return the captured audio.
+
+    A stop for a mode that no longer owns the recorder (a stale or duplicate
+    event) is ignored and returns None. When *discard* is True the buffer is
+    dropped and None returned — used by the safety timeout so an overrun
+    recording is never transcribed or pasted anywhere.
+    """
+    global _active_mode
+    with _rec_lock:
+        if _active_mode != mode:
+            log.info("Ignoring stale %s stop (recorder owner=%s).",
+                     mode, _active_mode)
+            return None
+        _cancel_timeout(mode)
+        audio = recorder.stop()
+        _active_mode = None
+    return None if discard else audio
+
+
+def _safety_stop(mode: str):
+    """Stop a recording that overran its safety cap and reset UI state.
+
+    In hold mode reaching the cap almost always means a key-release event was
+    lost, so the (possibly very long) audio is discarded rather than pasted
+    into whatever window has focus. In toggle mode the cap is a deliberate
+    convenience stop, so the audio is processed like a normal press-to-stop.
+    """
+    if config.HOLD_TO_RECORD:
+        _end_recording(mode, discard=True)
+        if hotkey_listener:
+            if mode == "dictation":
+                hotkey_listener.reset_dictation_state()
+            else:
+                hotkey_listener.reset_assistant_state()
+        if tray:
+            tray.set_recording(False)
+        if widget:
+            widget.hide()
+    elif hotkey_listener:
+        # Toggle mode: fire the normal stop path so the audio is processed.
+        if mode == "dictation":
+            hotkey_listener.force_stop_dictation()
+        else:
+            hotkey_listener.force_stop_assistant()
+
+
+def _timeout_dictation(generation: int):
+    if generation != _rec_generation:
+        return  # a newer session is active; this timer is obsolete
+    log.warning("Dictation recording hit the %ds safety cap.",
+                getattr(config, "MAX_RECORD_SECONDS", 120))
+    _safety_stop("dictation")
+
+
+def _timeout_assistant(generation: int):
+    if generation != _rec_generation:
+        return  # a newer session is active; this timer is obsolete
+    log.warning("Assistant recording hit the %ds safety cap.",
+                getattr(config, "MAX_RECORD_SECONDS", 120))
+    _safety_stop("assistant")
 
 
 # ── Dictation callbacks (AltGr) ──────────────────────────────────────────
 
 def _on_hotkey_press():
-    global _rec_start
-    _rec_start = time.monotonic()
-    recorder.start()
+    _begin_recording("dictation")
     if tray:
         tray.set_recording(True)
     if widget:
         widget.show_recording()
-    _start_timeout("dictation")
     log.info("Recording started (dictation).")
 
 
 def _on_hotkey_release():
-    _cancel_timeout("dictation")
-    audio = recorder.stop()
+    audio = _end_recording("dictation")
     duration = time.monotonic() - _rec_start
     if tray:
         tray.set_recording(False)
@@ -208,21 +301,17 @@ def _on_hotkey_release():
 # ── Assistant callbacks (Ctrl+R) ──────────────────────────────────────────
 
 def _on_assist_press():
-    global _rec_start
-    _rec_start = time.monotonic()
-    recorder.start()
+    _begin_recording("assistant")
     if tray:
         tray.set_recording(True)
     if widget:
         widget.show_assistant()
         widget.set_expression("listening")
-    _start_timeout("assistant")
     log.info("Recording started (assistant).")
 
 
 def _on_assist_release():
-    _cancel_timeout("assistant")
-    audio = recorder.stop()
+    audio = _end_recording("assistant")
     duration = time.monotonic() - _rec_start
     if tray:
         tray.set_recording(False)

--- a/main.py
+++ b/main.py
@@ -116,6 +116,12 @@ def _load_settings():
     whisper = db.get_setting("whisper_model", "")
     if whisper:
         config.MODEL_SIZE = whisper
+    device = db.get_setting("device", "")
+    if device in {"cpu", "cuda"}:
+        config.DEVICE = device
+    compute_type = db.get_setting("compute_type", "")
+    if compute_type in {"int8", "float16", "float32"}:
+        config.COMPUTE_TYPE = compute_type
     lang = db.get_setting("language", "")
     if lang:
         config.LANGUAGE = lang

--- a/settings_window.py
+++ b/settings_window.py
@@ -2,7 +2,7 @@
 
 Allows the user to configure:
   - Recording mode: hold-to-record vs toggle (press to start/stop)
-  - Max recording duration in seconds (toggle mode only)
+  - Max recording duration in seconds (safety cap for both modes)
   - Keyboard shortcuts for dictation and assistant
   - Microphone device selection
   - Local assistant provider, model, and URL
@@ -230,7 +230,7 @@ class SettingsWindow:
         )
         self._toggle_btn.pack(side="left")
 
-        # Max duration (toggle only)
+        # Max duration (safety cap for both hold and toggle modes)
         self._slider_section = ctk.CTkFrame(pad, fg_color="transparent")
         self._slider_section.pack(fill="x")
 

--- a/settings_window.py
+++ b/settings_window.py
@@ -8,6 +8,7 @@ Allows the user to configure:
   - Local assistant provider, model, and URL
   - Whisper model size
   - Compute device (CPU / CUDA) and precision (int8 / float16 / float32)
+  - Recording audio cues (start/stop tones)
   - Interface language
 """
 
@@ -112,6 +113,9 @@ class SettingsWindow:
         self._device_dropdown = None
         self._compute_dropdown = None
         self._perf_note = None
+        # Recording audio cues
+        self._audio_cues_switch_var = None
+        self._audio_cues_switch = None
         # Recognition language
         self._recog_dropdown = None
         self._recog_hint = None
@@ -264,6 +268,31 @@ class SettingsWindow:
             command=self._on_slider_change,
         )
         self._slider.pack(fill="x")
+
+        # Recording audio cues toggle (issue #24)
+        cues_row = ctk.CTkFrame(pad, fg_color="transparent")
+        cues_row.pack(fill="x", pady=(T.PAD_M, 0))
+
+        ctk.CTkLabel(cues_row, text=locales.get("setting_audio_cues"),
+                     font=T.FONT_SMALL, text_color=T.FG_DIM,
+                     anchor="w").pack(side="left")
+
+        self._audio_cues_switch_var = tk.StringVar(
+            value="1" if db.get_setting("audio_cues", "0") == "1" else "0")
+        self._audio_cues_switch = ctk.CTkSwitch(
+            cues_row, text="", variable=self._audio_cues_switch_var,
+            onvalue="1", offvalue="0",
+            command=self._on_audio_cues_toggle,
+            fg_color=T.BG_INPUT, progress_color=T.ACCENT,
+            button_color=T.FG, button_hover_color=T.ACCENT_HOVER,
+        )
+        self._audio_cues_switch.pack(side="right")
+
+        ctk.CTkLabel(
+            pad, text=locales.get("setting_audio_cues_hint"),
+            font=T.FONT_TINY, text_color=T.FG_DIM, anchor="w",
+            wraplength=_WIN_W - 3 * T.PAD_L, justify="left",
+        ).pack(fill="x", pady=(T.PAD_S, 0))
 
         self._build_separator(pad)
 
@@ -942,6 +971,14 @@ class SettingsWindow:
         if self._perf_note:
             self._perf_note.configure(
                 text=locales.get("setting_restart_required"))
+
+    # ── Audio cues callback (issue #24) ───────────────────────────────────
+
+    def _on_audio_cues_toggle(self):
+        enabled = self._audio_cues_switch_var.get() == "1"
+        config.AUDIO_CUES = enabled
+        db.save_setting("audio_cues", "1" if enabled else "0")
+        log.info("Recording audio cues: %s", "ON" if enabled else "OFF")
 
     # ── Language callback ─────────────────────────────────────────────────
 

--- a/settings_window.py
+++ b/settings_window.py
@@ -7,6 +7,7 @@ Allows the user to configure:
   - Microphone device selection
   - Local assistant provider, model, and URL
   - Whisper model size
+  - Compute device (CPU / CUDA) and precision (int8 / float16 / float32)
   - Interface language
 """
 
@@ -31,6 +32,10 @@ _TITLE_H = 40
 
 # Whisper model options
 _WHISPER_MODELS = ["tiny", "base", "small", "medium", "large-v3"]
+
+# Inference device / precision options (issue #23)
+_DEVICES = [("cpu", "CPU"), ("cuda", "CUDA (NVIDIA GPU)")]
+_COMPUTE_TYPES = ["int8", "float16", "float32"]
 
 # Supported languages
 _LANGUAGES = [("en", "English"), ("it", "Italiano"), ("de", "Deutsch")]
@@ -103,6 +108,10 @@ class SettingsWindow:
         self._assistant_url_entry = None
         # Whisper
         self._whisper_dropdown = None
+        # Performance (device / compute type)
+        self._device_dropdown = None
+        self._compute_dropdown = None
+        self._perf_note = None
         # Recognition language
         self._recog_dropdown = None
         self._recog_hint = None
@@ -435,6 +444,48 @@ class SettingsWindow:
 
         self._build_separator(pad)
 
+        # ── 5c. Performance: compute device & precision (issue #23) ──
+        self._build_section_label(pad, locales.get("setting_device"))
+
+        self._device_dropdown = ctk.CTkComboBox(
+            pad, values=[label for _, label in _DEVICES], font=T.FONT_SMALL,
+            dropdown_font=T.FONT_SMALL,
+            fg_color=T.BG_CARD, border_color=T.BORDER,
+            button_color=T.BORDER_GLOW, button_hover_color=T.FG_DIM,
+            dropdown_fg_color=T.BG_CARD, dropdown_hover_color=T.BG_HOVER,
+            dropdown_text_color=T.FG, text_color=T.FG,
+            height=36, corner_radius=6,
+            command=self._on_device_change, state="readonly",
+        )
+        self._device_dropdown.pack(fill="x", pady=(0, T.PAD_M))
+
+        self._build_section_label(pad, locales.get("setting_compute_type"))
+
+        self._compute_dropdown = ctk.CTkComboBox(
+            pad, values=_COMPUTE_TYPES, font=T.FONT_SMALL,
+            dropdown_font=T.FONT_SMALL,
+            fg_color=T.BG_CARD, border_color=T.BORDER,
+            button_color=T.BORDER_GLOW, button_hover_color=T.FG_DIM,
+            dropdown_fg_color=T.BG_CARD, dropdown_hover_color=T.BG_HOVER,
+            dropdown_text_color=T.FG, text_color=T.FG,
+            height=36, corner_radius=6,
+            command=self._on_compute_change, state="readonly",
+        )
+        self._compute_dropdown.pack(fill="x", pady=(0, T.PAD_S))
+
+        ctk.CTkLabel(
+            pad, text=locales.get("setting_device_hint"),
+            font=T.FONT_TINY, text_color=T.FG_DIM, anchor="w",
+            wraplength=_WIN_W - 3 * T.PAD_L, justify="left",
+        ).pack(fill="x")
+
+        self._perf_note = ctk.CTkLabel(
+            pad, text="", font=T.FONT_TINY, text_color=T.FG_DIM, anchor="w",
+        )
+        self._perf_note.pack(fill="x")
+
+        self._build_separator(pad)
+
         # ── 6. Language ──────────────────────────────────────────────
         self._build_section_label(pad, locales.get("setting_language"))
 
@@ -664,6 +715,15 @@ class SettingsWindow:
         if self._whisper_dropdown:
             self._whisper_dropdown.set(config.MODEL_SIZE)
 
+        # Performance: compute device & precision
+        if self._device_dropdown:
+            device_label = next(
+                (label for key, label in _DEVICES if key == config.DEVICE),
+                _DEVICES[0][1])
+            self._device_dropdown.set(device_label)
+        if self._compute_dropdown:
+            self._compute_dropdown.set(config.COMPUTE_TYPE)
+
         # Recognition language
         if self._recog_dropdown:
             current = config.WHISPER_LANGUAGE
@@ -858,6 +918,30 @@ class SettingsWindow:
             self._whisper_note.configure(text=locales.get("setting_restart_required"))
         if self._cb_whisper_change:
             self._cb_whisper_change(value)
+
+    # ── Performance callbacks (issue #23) ─────────────────────────────────
+
+    def _on_device_change(self, selected: str):
+        device = next((key for key, label in _DEVICES if label == selected),
+                      "cpu")
+        if device == config.DEVICE:
+            return
+        config.DEVICE = device
+        db.save_setting("device", device)
+        log.info("Compute device set to: %s", device)
+        if self._perf_note:
+            self._perf_note.configure(
+                text=locales.get("setting_restart_required"))
+
+    def _on_compute_change(self, value: str):
+        if value == config.COMPUTE_TYPE:
+            return
+        config.COMPUTE_TYPE = value
+        db.save_setting("compute_type", value)
+        log.info("Compute type set to: %s", value)
+        if self._perf_note:
+            self._perf_note.configure(
+                text=locales.get("setting_restart_required"))
 
     # ── Language callback ─────────────────────────────────────────────────
 

--- a/test_audio_cues.py
+++ b/test_audio_cues.py
@@ -1,0 +1,85 @@
+"""Audio-cue generation and playback tests (issue #24).
+
+The winsound backend is mocked: it is Windows-only and would make noise. These
+tests pin that the tones are valid WAV, that playback uses SND_MEMORY, that a
+failing backend never propagates, and that start/stop use distinct pitches.
+
+Run:  python -m unittest test_audio_cues -v
+"""
+
+import io
+import sys
+import unittest
+import wave
+from unittest.mock import Mock, patch
+
+import audio_cues
+
+
+class TestToneRendering(unittest.TestCase):
+    def setUp(self):
+        audio_cues._cache.clear()
+
+    def test_render_produces_readable_mono_16bit_wav(self):
+        data = audio_cues._render_tone(audio_cues._START_FREQ)
+        with wave.open(io.BytesIO(data), "rb") as w:
+            self.assertEqual(w.getnchannels(), 1)
+            self.assertEqual(w.getsampwidth(), 2)
+            self.assertEqual(w.getframerate(), audio_cues._SAMPLE_RATE)
+            self.assertGreater(w.getnframes(), 0)
+
+    def test_render_is_cached(self):
+        first = audio_cues._render_tone(audio_cues._STOP_FREQ)
+        second = audio_cues._render_tone(audio_cues._STOP_FREQ)
+        self.assertIs(first, second)
+
+
+class TestPlayback(unittest.TestCase):
+    @staticmethod
+    def _fake_winsound():
+        ws = Mock()
+        ws.SND_MEMORY = 4
+        ws.SND_ASYNC = 1
+        return ws
+
+    def test_play_uses_snd_memory_async(self):
+        ws = self._fake_winsound()
+        with patch.dict(sys.modules, {"winsound": ws}):
+            audio_cues._play(audio_cues._START_FREQ)
+        ws.PlaySound.assert_called_once()
+        args, _ = ws.PlaySound.call_args
+        self.assertIsInstance(args[0], (bytes, bytearray))
+        self.assertEqual(args[1], ws.SND_MEMORY | ws.SND_ASYNC)
+
+    def test_play_swallows_backend_errors(self):
+        ws = self._fake_winsound()
+        ws.PlaySound.side_effect = RuntimeError("no audio device")
+        with patch.dict(sys.modules, {"winsound": ws}):
+            audio_cues._play(audio_cues._STOP_FREQ)  # must not raise
+
+    def test_play_async_is_noop_off_windows(self):
+        with patch.object(audio_cues.sys, "platform", "linux"), \
+             patch.object(audio_cues.threading, "Thread") as thread:
+            audio_cues._play_async(audio_cues._START_FREQ)
+        thread.assert_not_called()
+
+    def test_play_async_spawns_daemon_thread_on_windows(self):
+        with patch.object(audio_cues.sys, "platform", "win32"), \
+             patch.object(audio_cues.threading, "Thread") as thread:
+            audio_cues._play_async(audio_cues._START_FREQ)
+        thread.assert_called_once()
+        self.assertTrue(thread.call_args.kwargs.get("daemon"))
+        thread.return_value.start.assert_called_once_with()
+
+    def test_start_is_higher_pitch_than_stop(self):
+        with patch.object(audio_cues, "_play_async") as play:
+            audio_cues.play_start()
+            audio_cues.play_stop()
+        freqs = [c.args[0] for c in play.call_args_list]
+        self.assertEqual(
+            freqs, [audio_cues._START_FREQ, audio_cues._STOP_FREQ])
+        self.assertGreater(audio_cues._START_FREQ, audio_cues._STOP_FREQ)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_hotkey.py
+++ b/test_hotkey.py
@@ -178,5 +178,48 @@ class TestBareModifierHotkeys(unittest.TestCase):
             mock_log.warning.assert_not_called()
 
 
+class TestSafetyStateReset(unittest.TestCase):
+    """Issue #25: the safety timeout must un-wedge a stuck hold-mode flag."""
+
+    def _listener(self):
+        cbs = {name: Mock() for name in
+               ("press", "release", "assist_press", "assist_release")}
+        return HotkeyListener(
+            on_press_cb=cbs["press"],
+            on_release_cb=cbs["release"],
+            on_assist_press_cb=cbs["assist_press"],
+            on_assist_release_cb=cbs["assist_release"],
+        ), cbs
+
+    def test_reset_dictation_clears_flags_without_callback(self):
+        listener, cbs = self._listener()
+        listener._dict_pressed = True
+        listener._dict_recording = True
+        listener.reset_dictation_state()
+        self.assertFalse(listener._dict_pressed)
+        self.assertFalse(listener._dict_recording)
+        cbs["release"].assert_not_called()
+
+    def test_reset_assistant_clears_flags_without_callback(self):
+        listener, cbs = self._listener()
+        listener._assist_pressed = True
+        listener._assist_recording = True
+        listener.reset_assistant_state()
+        self.assertFalse(listener._assist_pressed)
+        self.assertFalse(listener._assist_recording)
+        cbs["assist_release"].assert_not_called()
+
+    def test_press_fires_again_after_reset(self):
+        # A stuck _dict_pressed swallows presses; reset restores the hotkey.
+        with patch.multiple(config, HOTKEY=Key.alt_gr, HOLD_TO_RECORD=True):
+            listener, cbs = self._listener()
+            listener._dict_pressed = True  # simulate a lost key-release
+            listener._handle_press(Key.alt_gr)
+            cbs["press"].assert_not_called()  # wedged
+            listener.reset_dictation_state()
+            listener._handle_press(Key.alt_gr)
+            cbs["press"].assert_called_once_with()  # recovered
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_recording_safety.py
+++ b/test_recording_safety.py
@@ -1,0 +1,142 @@
+"""Recorder safety-cap and session-ownership tests (issue #25).
+
+The dictation and assistant pipelines share a single Recorder. In hold mode a
+lost key-release event used to leave the mic recording with no maximum
+duration, and accumulated audio could leak from one session/mode into another.
+These tests pin the fixes: a safety cap that applies in hold mode too, stale
+timers that self-cancel, and ownership that discards overlapping sessions.
+
+Run:  python -m unittest test_recording_safety -v
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import main
+
+
+class _RecordingBase(unittest.TestCase):
+    """Mock the shared recorder/UI singletons and reset ownership globals."""
+
+    def setUp(self):
+        self.recorder = Mock()
+        self.tray = Mock()
+        self.widget = Mock()
+        self.listener = Mock()
+        self._patches = [
+            patch.object(main, "recorder", self.recorder),
+            patch.object(main, "tray", self.tray),
+            patch.object(main, "widget", self.widget),
+            patch.object(main, "hotkey_listener", self.listener),
+            # Replace the real Timer so _start_timeout never spawns a thread.
+            patch.object(main.threading, "Timer", Mock()),
+        ]
+        for p in self._patches:
+            p.start()
+        self._reset_globals()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self._reset_globals()
+
+    @staticmethod
+    def _reset_globals():
+        main._active_mode = None
+        main._rec_generation = 0
+        main._dict_timeout_timer = None
+        main._assist_timeout_timer = None
+
+
+class TestSessionOwnership(_RecordingBase):
+    def test_begin_sets_owner_and_bumps_generation(self):
+        gen = main._begin_recording("dictation")
+        self.assertEqual(gen, 1)
+        self.assertEqual(main._active_mode, "dictation")
+        self.recorder.start.assert_called_once_with()
+        self.assertGreater(main._rec_start, 0)
+
+    def test_normal_stop_returns_audio_and_clears_owner(self):
+        self.recorder.stop.return_value = "AUDIO"
+        main._begin_recording("dictation")
+        audio = main._end_recording("dictation")
+        self.assertEqual(audio, "AUDIO")
+        self.assertIsNone(main._active_mode)
+
+    def test_stale_stop_is_ignored(self):
+        main._begin_recording("dictation")
+        self.recorder.stop.reset_mock()
+        # A stop for a mode that does not own the recorder must be a no-op.
+        result = main._end_recording("assistant")
+        self.assertIsNone(result)
+        self.recorder.stop.assert_not_called()
+        self.assertEqual(main._active_mode, "dictation")
+
+    def test_overlapping_press_discards_stale_session(self):
+        # Dictation left running (lost release), then an assistant press.
+        main._begin_recording("dictation")
+        self.recorder.reset_mock()
+        gen2 = main._begin_recording("assistant")
+        # The inherited buffer is dropped (stop) before a fresh start.
+        self.recorder.stop.assert_called_once_with()
+        self.recorder.start.assert_called_once_with()
+        self.assertEqual(main._active_mode, "assistant")
+        self.assertEqual(gen2, 2)
+        # The wedged dictation hotkey flag is reset so it can fire again.
+        self.listener.reset_dictation_state.assert_called_once_with()
+
+
+class TestHoldModeSafetyTimeout(_RecordingBase):
+    def test_hold_timeout_discards_audio_and_resets_state(self):
+        with patch.object(main.config, "HOLD_TO_RECORD", True):
+            gen = main._begin_recording("dictation")
+            self.recorder.stop.return_value = "LONG_AUDIO"
+            main._timeout_dictation(gen)
+        # Mic stopped, but the overrun audio is discarded, not processed.
+        self.recorder.stop.assert_called_once_with()
+        self.assertIsNone(main._active_mode)
+        self.listener.reset_dictation_state.assert_called_once_with()
+        self.tray.set_recording.assert_called_with(False)
+        self.widget.hide.assert_called_once_with()
+
+    def test_assistant_hold_timeout_discards_and_resets(self):
+        with patch.object(main.config, "HOLD_TO_RECORD", True):
+            gen = main._begin_recording("assistant")
+            main._timeout_assistant(gen)
+        self.assertIsNone(main._active_mode)
+        self.listener.reset_assistant_state.assert_called_once_with()
+        self.widget.hide.assert_called_once_with()
+
+    def test_stale_timer_from_previous_generation_is_noop(self):
+        with patch.object(main.config, "HOLD_TO_RECORD", True):
+            main._begin_recording("dictation")   # generation 1
+            main._end_recording("dictation")     # ends cleanly
+            main._begin_recording("dictation")   # generation 2 now active
+            self.recorder.reset_mock()
+            self.listener.reset_mock()
+            # A leftover timer from generation 1 fires late.
+            main._timeout_dictation(1)
+        self.recorder.stop.assert_not_called()
+        self.listener.reset_dictation_state.assert_not_called()
+        self.assertEqual(main._active_mode, "dictation")
+
+
+class TestToggleModeSafetyTimeout(_RecordingBase):
+    def test_toggle_timeout_delegates_to_force_stop(self):
+        with patch.object(main.config, "HOLD_TO_RECORD", False):
+            gen = main._begin_recording("dictation")
+            main._timeout_dictation(gen)
+        # Toggle mode processes the audio via the listener's normal stop path.
+        self.listener.force_stop_dictation.assert_called_once_with()
+        # It must not take the hold-mode discard path.
+        self.widget.hide.assert_not_called()
+
+    def test_disabled_cap_arms_no_timer(self):
+        with patch.object(main.config, "MAX_RECORD_SECONDS", 0):
+            main._begin_recording("dictation")
+        # MAX_RECORD_SECONDS = 0 disables the safety timer entirely.
+        main.threading.Timer.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_runtime_settings.py
+++ b/test_runtime_settings.py
@@ -1,9 +1,11 @@
-"""Runtime configurability of compute device / precision (issue #23).
+"""Runtime configurability of device / compute type / audio cues.
 
-DEVICE and COMPUTE_TYPE are selectable from Settings and persisted, so packaged
-users can enable CUDA without editing config.py. The Settings callbacks are
-exercised on a bare SettingsWindow shell (no Tk); the startup load path is
-exercised through main._load_settings.
+Issue #23: DEVICE and COMPUTE_TYPE selectable from Settings + persisted, so
+packaged users can enable CUDA without editing config.py.
+Issue #24: the audio-cues toggle persists and updates config.
+
+The Settings callbacks are exercised on a bare SettingsWindow shell (no Tk),
+and the startup load path is exercised through main._load_settings.
 
 Run:  python -m unittest test_runtime_settings -v
 """
@@ -20,6 +22,7 @@ def _window_shell():
     """A SettingsWindow with only the attributes the callbacks touch."""
     w = object.__new__(settings_window.SettingsWindow)
     w._perf_note = Mock()
+    w._audio_cues_switch_var = Mock()
     return w
 
 
@@ -50,28 +53,51 @@ class TestPerformanceSettings(unittest.TestCase):
         save.assert_called_once_with("compute_type", "float16")
 
 
+class TestAudioCuesSetting(unittest.TestCase):
+    @patch.object(settings_window.db, "save_setting")
+    def test_toggle_on_updates_config_and_persists(self, save):
+        w = _window_shell()
+        w._audio_cues_switch_var.get.return_value = "1"
+        with patch.object(config, "AUDIO_CUES", False):
+            w._on_audio_cues_toggle()
+            self.assertTrue(config.AUDIO_CUES)
+        save.assert_called_once_with("audio_cues", "1")
+
+    @patch.object(settings_window.db, "save_setting")
+    def test_toggle_off_updates_config_and_persists(self, save):
+        w = _window_shell()
+        w._audio_cues_switch_var.get.return_value = "0"
+        with patch.object(config, "AUDIO_CUES", True):
+            w._on_audio_cues_toggle()
+            self.assertFalse(config.AUDIO_CUES)
+        save.assert_called_once_with("audio_cues", "0")
+
+
 class TestLoadSettings(unittest.TestCase):
-    """main._load_settings applies persisted device/compute to config."""
+    """main._load_settings applies persisted device/compute/cues to config."""
 
     def _load_with(self, values):
         def fake_get(key, default=""):
             return values.get(key, "")
         with patch.object(main.db, "get_setting", side_effect=fake_get), \
              patch.object(config, "DEVICE", "cpu"), \
-             patch.object(config, "COMPUTE_TYPE", "int8"):
+             patch.object(config, "COMPUTE_TYPE", "int8"), \
+             patch.object(config, "AUDIO_CUES", False):
             main._load_settings()
-            return config.DEVICE, config.COMPUTE_TYPE
+            return config.DEVICE, config.COMPUTE_TYPE, config.AUDIO_CUES
 
     def test_valid_values_are_applied(self):
-        device, compute = self._load_with({
+        device, compute, cues = self._load_with({
             "device": "cuda",
             "compute_type": "float16",
+            "audio_cues": "1",
         })
         self.assertEqual(device, "cuda")
         self.assertEqual(compute, "float16")
+        self.assertTrue(cues)
 
     def test_invalid_device_and_compute_are_ignored(self):
-        device, compute = self._load_with({
+        device, compute, _ = self._load_with({
             "device": "gpu-typo",
             "compute_type": "bogus",
         })
@@ -79,9 +105,10 @@ class TestLoadSettings(unittest.TestCase):
         self.assertEqual(compute, "int8")   # left at default
 
     def test_absent_settings_leave_defaults(self):
-        device, compute = self._load_with({})
+        device, compute, cues = self._load_with({})
         self.assertEqual(device, "cpu")
         self.assertEqual(compute, "int8")
+        self.assertFalse(cues)
 
 
 if __name__ == "__main__":

--- a/test_runtime_settings.py
+++ b/test_runtime_settings.py
@@ -1,0 +1,88 @@
+"""Runtime configurability of compute device / precision (issue #23).
+
+DEVICE and COMPUTE_TYPE are selectable from Settings and persisted, so packaged
+users can enable CUDA without editing config.py. The Settings callbacks are
+exercised on a bare SettingsWindow shell (no Tk); the startup load path is
+exercised through main._load_settings.
+
+Run:  python -m unittest test_runtime_settings -v
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import config
+import main
+import settings_window
+
+
+def _window_shell():
+    """A SettingsWindow with only the attributes the callbacks touch."""
+    w = object.__new__(settings_window.SettingsWindow)
+    w._perf_note = Mock()
+    return w
+
+
+class TestPerformanceSettings(unittest.TestCase):
+    @patch.object(settings_window.db, "save_setting")
+    def test_device_change_persists_and_flags_restart(self, save):
+        w = _window_shell()
+        with patch.object(config, "DEVICE", "cpu"):
+            w._on_device_change("CUDA (NVIDIA GPU)")
+            self.assertEqual(config.DEVICE, "cuda")
+        save.assert_called_once_with("device", "cuda")
+        w._perf_note.configure.assert_called_once()
+
+    @patch.object(settings_window.db, "save_setting")
+    def test_device_change_ignored_when_unchanged(self, save):
+        w = _window_shell()
+        with patch.object(config, "DEVICE", "cpu"):
+            w._on_device_change("CPU")
+        save.assert_not_called()
+        w._perf_note.configure.assert_not_called()
+
+    @patch.object(settings_window.db, "save_setting")
+    def test_compute_change_persists(self, save):
+        w = _window_shell()
+        with patch.object(config, "COMPUTE_TYPE", "int8"):
+            w._on_compute_change("float16")
+            self.assertEqual(config.COMPUTE_TYPE, "float16")
+        save.assert_called_once_with("compute_type", "float16")
+
+
+class TestLoadSettings(unittest.TestCase):
+    """main._load_settings applies persisted device/compute to config."""
+
+    def _load_with(self, values):
+        def fake_get(key, default=""):
+            return values.get(key, "")
+        with patch.object(main.db, "get_setting", side_effect=fake_get), \
+             patch.object(config, "DEVICE", "cpu"), \
+             patch.object(config, "COMPUTE_TYPE", "int8"):
+            main._load_settings()
+            return config.DEVICE, config.COMPUTE_TYPE
+
+    def test_valid_values_are_applied(self):
+        device, compute = self._load_with({
+            "device": "cuda",
+            "compute_type": "float16",
+        })
+        self.assertEqual(device, "cuda")
+        self.assertEqual(compute, "float16")
+
+    def test_invalid_device_and_compute_are_ignored(self):
+        device, compute = self._load_with({
+            "device": "gpu-typo",
+            "compute_type": "bogus",
+        })
+        self.assertEqual(device, "cpu")     # left at default
+        self.assertEqual(compute, "int8")   # left at default
+
+    def test_absent_settings_leave_defaults(self):
+        device, compute = self._load_with({})
+        self.assertEqual(device, "cpu")
+        self.assertEqual(compute, "int8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses three open issues reported by @MaxiKingXXL. Split into three self-contained, per-issue commits - reviewable one at a time.

## `fixes #25` - Hold-mode recording safety cap + session isolation
In hold-to-record mode a recording had **no maximum duration**: a missed key-release left the mic recording indefinitely, and audio could leak across modes via the shared `Recorder`.

- Arm the `MAX_RECORD_SECONDS` safety timer in **hold mode too** (was toggle-only). On timeout in hold mode the mic stops and the overrun audio is **discarded**, never pasted into the focused window.
- Track recorder **ownership** (single owner + generation counter): stale timers self-cancel, stops for a non-owning mode are ignored, and an inherited buffer is discarded when a new session starts.
- New `HotkeyListener.reset_dictation_state` / `reset_assistant_state` so a lost key-release no longer wedges the hotkey.

## `fixes #23` - Compute device & precision configurable at runtime
Packaged-exe users couldn't enable CUDA or change precision without editing `config.py`.

- Settings gains a **Performance** section: compute device (CPU / CUDA) and precision (int8 / float16 / float32), a CUDA-runtime hint, and a restart-required note.
- `main._load_settings` reads and **validates** the persisted `device` / `compute_type` (invalid values ignored, defaults kept).

## `fixes #24` - Optional audio cues for dictation start/stop
Off by default; opt-in from Settings for eyes-free confirmation and pacing.

- New `audio_cues.py`: renders two short WAV tones in memory (high on start, low on stop) and plays them with `winsound.PlaySound(SND_MEMORY | SND_ASYNC)` on a daemon thread - non-blocking, failures swallowed, no-op off Windows.
- Wired into the **dictation path only**; exactly one stop cue per session across hold / toggle / timeout.

## Testing
- New: `test_recording_safety.py`, `test_audio_cues.py`, `test_runtime_settings.py`, plus reset-state cases in `test_hotkey.py`.
- Full suite: **132 passed, 88 subtests passed**.
- New user-facing strings localised in EN / IT / DE.