### PR TITLE
Add floating agent panel for voice-delete confirmation

### DIFF
--- a/agent_panel.py
+++ b/agent_panel.py
@@ -1,0 +1,281 @@
+"""Expanded 'agent' panel for WritHer — the rich voice-delete confirmation.
+
+A dedicated floating window (borderless, topmost) that shows the confirm card
+from the design prototype: a dark rounded panel with an amber gradient border
++ soft glow, white Pandora eyes, the prompt, and a live countdown ring. It is
+kept fully separate from the pill widget (widget.py) so the pill is untouched.
+
+Everything is rendered with Pillow. Transparency uses a magenta chromakey
+(#ff00ff) — a colour the design can never produce, so the soft glow never
+leaves stray transparent pixels (the near-black key #000001 did).
+
+Public API (thread-safe — calls are marshalled onto the Tk main thread):
+    panel = AgentPanel(root)
+    panel.show_confirm(prompt, seconds, on_timeout=cb)
+    panel.hide()
+"""
+
+import ctypes
+import math
+import time
+import tkinter as tk
+from PIL import Image, ImageDraw, ImageFilter, ImageFont, ImageTk
+
+# ── constants ─────────────────────────────────────────────────────────────
+S = 2                       # supersample for crisp borders/text
+CHROMA = (255, 0, 255)
+CHROMA_HEX = "#ff00ff"
+
+BLACK = (0, 0, 0); WHITE = (255, 255, 255)
+FG = (242, 242, 247); DIM = (139, 139, 156); FAINT = (86, 86, 103)
+LINE = (32, 32, 42); AMBER = (255, 176, 32)
+
+PW, PH = 400, 140           # panel size (final px)
+RAD = 22
+
+
+# ── Win32: don't steal focus (same trick as widget.py) ────────────────────
+def _no_activate(hwnd: int) -> None:
+    try:
+        GWL_EXSTYLE = -20
+        WS_EX_NOACTIVATE = 0x08000000
+        WS_EX_TOOLWINDOW = 0x00000080
+        s = ctypes.windll.user32.GetWindowLongW(hwnd, GWL_EXSTYLE)
+        ctypes.windll.user32.SetWindowLongW(
+            hwnd, GWL_EXSTYLE, s | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW)
+    except Exception:
+        pass
+
+
+# ── fonts (Segoe UI + Consolas), rendered at supersample size ─────────────
+_FONTS = {}
+def _font(pt, bold=False, mono=False):
+    key = (pt, bold, mono)
+    if key in _FONTS:
+        return _FONTS[key]
+    path = ("C:/Windows/Fonts/consolab.ttf" if (mono and bold) else
+            "C:/Windows/Fonts/consola.ttf" if mono else
+            "C:/Windows/Fonts/segoeuib.ttf" if bold else
+            "C:/Windows/Fonts/segoeui.ttf")
+    try:
+        f = ImageFont.truetype(path, int(pt * S))
+    except Exception:
+        f = ImageFont.load_default()
+    _FONTS[key] = f
+    return f
+
+
+def _text(d, xy, s, f, fill, anchor="la"):
+    d.text((xy[0] * S, xy[1] * S), s, font=f, fill=fill, anchor=anchor)
+
+def _tw(d, s, f):
+    return d.textlength(s, font=f) / S
+
+def _wrap(d, s, f, maxw):
+    words, lines, cur = s.split(), [], ""
+    for w in words:
+        t = (cur + " " + w).strip()
+        if _tw(d, t, f) <= maxw:
+            cur = t
+        else:
+            if cur:
+                lines.append(cur)
+            cur = w
+    if cur:
+        lines.append(cur)
+    return lines
+
+
+def _grad(w, h, c0, c1):
+    base = Image.new("RGB", (w, 1)); px = base.load()
+    for x in range(w):
+        t = x / max(1, w - 1)
+        px[x, 0] = tuple(int(c0[i] + (c1[i] - c0[i]) * t) for i in range(3))
+    return base.resize((w, h))
+
+
+# ── cached pieces (built once) ────────────────────────────────────────────
+_GLOW = None
+def _glow():
+    global _GLOW
+    if _GLOW is None:
+        n = 64
+        a = Image.new("L", (n, n), 0)
+        ImageDraw.Draw(a).ellipse([n * 0.32, n * 0.32, n * 0.68, n * 0.68], fill=255)
+        a = a.filter(ImageFilter.GaussianBlur(n * 0.12))
+        g = Image.new("RGBA", (n, n), (255, 255, 255, 0))
+        g.putalpha(a.point(lambda v: int(v * 0.72)))
+        _GLOW = g
+    return _GLOW
+
+
+_BORDER = None
+def _border_img():
+    """Panel base: black fill + amber gradient border with soft inner glow."""
+    global _BORDER
+    if _BORDER is not None:
+        return _BORDER
+    W, H = PW * S, PH * S
+    img = Image.new("RGB", (W, H), BLACK)
+    ring = Image.new("L", (W, H), 0)
+    rd = ImageDraw.Draw(ring)
+    bw = max(2, int(1.7 * S))
+    rd.rounded_rectangle([0, 0, W - 1, H - 1], radius=RAD * S, fill=255)
+    rd.rounded_rectangle([bw, bw, W - 1 - bw, H - 1 - bw],
+                         radius=max(1, RAD * S - bw), fill=0)
+    grad = _grad(W, H, AMBER, (255, 138, 61))
+    img.paste(grad, (0, 0),
+              ring.filter(ImageFilter.GaussianBlur(int(3.5 * S))).point(lambda a: int(a * 0.55)))
+    img.paste(grad, (0, 0), ring)
+    _BORDER = img
+    return img
+
+
+_MASK = None
+def _mask():
+    global _MASK
+    if _MASK is None:
+        m = Image.new("L", (PW, PH), 0)
+        ImageDraw.Draw(m).rounded_rectangle([0, 0, PW - 1, PH - 1], radius=RAD, fill=255)
+        _MASK = m.point(lambda a: 255 if a >= 128 else 0)
+    return _MASK
+
+
+def _eyes(img, cx, cy, tick):
+    cx, cy = cx * S, cy * S
+    spread = 13 * S
+    r = 6.5 * S * (0.9 + 0.12 * math.sin(tick * 0.16))
+    lx, rx = cx - spread, cx + spread
+    gsz = max(2, int(r * 6.2))
+    gg = _glow().resize((gsz, gsz))
+    for ex in (lx, rx):
+        img.paste(gg, (int(ex - gsz / 2), int(cy - gsz / 2)), gg)
+    d = ImageDraw.Draw(img)
+    for ex in (lx, rx):
+        d.ellipse([ex - r, cy - r, ex + r, cy + r], fill=WHITE)
+
+
+def render_confirm(prompt, remaining, total, tick, hint="di' «sì» o «no»"):
+    """Compose the confirm panel (magenta corners → transparent)."""
+    img = _border_img().copy()
+    _eyes(img, 42, 34, tick)
+    d = ImageDraw.Draw(img)
+    d.line([90 * S, 18 * S, 90 * S, 50 * S], fill=LINE, width=int(1 * S))
+    _text(d, (106, 25), "Assistente", _font(16.5, bold=True), FG)
+    tw = _tw(d, "Assistente", _font(16.5, bold=True))
+    _text(d, (106 + tw + 9, 27), "· confermi?", _font(13, mono=True), FAINT)
+
+    y = 66
+    for ln in _wrap(d, prompt, _font(16, bold=True), PW - 44):
+        _text(d, (22, y), ln, _font(16, bold=True), FG); y += 25
+
+    ry = PH - 30
+    cx, cy, rr = 34, ry, 13
+    d.ellipse([(cx - rr) * S, (cy - rr) * S, (cx + rr) * S, (cy + rr) * S], fill=(24, 24, 30))
+    frac = max(0.0, remaining / total) if total else 0.0
+    d.arc([(cx - rr) * S, (cy - rr) * S, (cx + rr) * S, (cy + rr) * S],
+          -90, -90 + 360 * frac, fill=AMBER, width=int(2.5 * S))
+    _text(d, (cx, cy), str(int(math.ceil(max(0, remaining)))),
+          _font(10.5, mono=True), DIM, anchor="mm")
+    _text(d, (58, ry - 8), hint, _font(12.5), DIM)
+
+    final = img.resize((PW, PH), Image.LANCZOS)
+    frame = Image.new("RGB", (PW, PH), CHROMA)
+    frame.paste(final, (0, 0), _mask())
+    return frame
+
+
+class AgentPanel:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.win = tk.Toplevel(root)
+        self.win.overrideredirect(True)
+        self.win.attributes("-topmost", True)
+        self.win.configure(bg=CHROMA_HEX)
+        self.win.wm_attributes("-transparentcolor", CHROMA_HEX)
+        sw = self.win.winfo_screenwidth(); sh = self.win.winfo_screenheight()
+        x = (sw - PW) // 2; y = sh - PH - 90
+        self.win.geometry("%dx%d+%d+%d" % (PW, PH, x, y))
+        self.canvas = tk.Canvas(self.win, width=PW, height=PH,
+                                highlightthickness=0, bg=CHROMA_HEX, bd=0)
+        self.canvas.pack()
+        self._imgid = self.canvas.create_image(0, 0, anchor="nw")
+        self._imgtk = None
+        self.win.withdraw()
+
+        self._visible = False
+        self._tick = 0
+        self._prompt = ""
+        self._hint = "di' «sì» o «no»"
+        self._until = 0.0
+        self._total = 1.0
+        self._on_timeout = None
+        self._fired = False
+        self._after = None
+        self.win.after(60, lambda: _no_activate(self.win.winfo_id()))
+
+    # ── public (thread-safe) ──────────────────────────────────────────────
+    def show_confirm(self, prompt: str, seconds: float, on_timeout=None, hint=None):
+        self.root.after(0, lambda: self._show(prompt, seconds, on_timeout, hint))
+
+    def hide(self):
+        self.root.after(0, self._hide)
+
+    # ── internals (Tk thread) ─────────────────────────────────────────────
+    def _show(self, prompt, seconds, on_timeout, hint=None):
+        self._prompt = prompt
+        if hint:
+            self._hint = hint
+        self._total = max(0.1, float(seconds))
+        self._until = time.monotonic() + seconds
+        self._on_timeout = on_timeout
+        self._fired = False
+        self._tick = 0
+        try:
+            self.win.deiconify()
+            self.win.lift()
+            self.win.attributes("-topmost", True)
+        except Exception:
+            pass
+        if not self._visible:
+            self._visible = True
+            if self._after is None:
+                self._loop()
+
+    def _loop(self):
+        if not self._visible or not self.win.winfo_exists():
+            self._after = None
+            return
+        self._tick += 1
+        remaining = self._until - time.monotonic()
+        if remaining <= 0:
+            remaining = 0
+            if not self._fired:
+                self._fired = True
+                cb = self._on_timeout
+                if cb:
+                    try:
+                        cb()
+                    except Exception:
+                        pass
+        try:
+            img = render_confirm(self._prompt, remaining, self._total,
+                                 self._tick, self._hint)
+            self._imgtk = ImageTk.PhotoImage(img)
+            self.canvas.itemconfig(self._imgid, image=self._imgtk)
+        except Exception:
+            pass
+        self._after = self.root.after(33, self._loop)
+
+    def _hide(self):
+        self._visible = False
+        if self._after is not None:
+            try:
+                self.root.after_cancel(self._after)
+            except Exception:
+                pass
+            self._after = None
+        try:
+            self.win.withdraw()
+        except Exception:
+            pass

--- a/locales.py
+++ b/locales.py
@@ -29,6 +29,8 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "reminder_deleted":     "Reminder '{message}' deleted (#{rid})",
         "reminder_set":         "Reminder set: {dt}",
         "delete_confirm_prompt": "Say yes within {seconds}s to delete this {item}",
+        "delete_confirm_widget": "Delete {item}?",
+        "delete_confirm_answer": "Say “yes” or “no”",
         "delete_confirm_repeat": "Please say yes or no ({seconds}s left)",
         "delete_confirm_timeout": "Delete confirmation timed out",
         "delete_cancelled":      "Delete cancelled",
@@ -188,6 +190,8 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "reminder_deleted":     "Reminder '{message}' eliminato (#{rid})",
         "reminder_set":         "Reminder impostato: {dt}",
         "delete_confirm_prompt": "Di' si entro {seconds}s per eliminare questo {item}",
+        "delete_confirm_widget": "Eliminare {item}?",
+        "delete_confirm_answer": "Di' «sì» o «no»",
         "delete_confirm_repeat": "Di' si o no ({seconds}s rimasti)",
         "delete_confirm_timeout": "Conferma eliminazione scaduta",
         "delete_cancelled":      "Eliminazione annullata",
@@ -340,6 +344,8 @@ _STRINGS: dict[str, dict[str, LocaleValue]] = {
         "reminder_deleted":     "Erinnerung '{message}' gelöscht (#{rid})",
         "reminder_set":         "Erinnerung gesetzt: {dt}",
         "delete_confirm_prompt": "Sagen Sie ja innerhalb von {seconds}s, um dieses {item} zu löschen",
+        "delete_confirm_widget": "{item} löschen?",
+        "delete_confirm_answer": "„ja“ oder „nein“ sagen",
         "delete_confirm_repeat": "Bitte sagen Sie ja oder nein ({seconds}s verbleiben)",
         "delete_confirm_timeout": "Löschbestätigung abgelaufen",
         "delete_cancelled":      "Löschen abgebrochen",
@@ -511,3 +517,20 @@ def get_choices(key: str) -> tuple[str, ...]:
     if isinstance(choices, tuple):
         return choices
     return (choices,)
+
+
+def get_all_choices(key: str) -> tuple[str, ...]:
+    """Return the choice list for *key* merged across every language.
+
+    Used for language-agnostic matching: a spoken yes/no confirmation should be
+    accepted regardless of which UI language is active (and regardless of which
+    language Whisper happened to pick for a single short word).
+    """
+    merged: list[str] = []
+    for table in _STRINGS.values():
+        val = table.get(key)
+        if isinstance(val, tuple):
+            merged.extend(val)
+        elif isinstance(val, str):
+            merged.append(val)
+    return tuple(dict.fromkeys(merged))   # de-dupe, preserve order

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import re
 import threading
 import time
 import tkinter as tk
+import unicodedata
 
 # Fix DPI awareness before any window is created.
 # CustomTkinter changes the DPI mode which shifts widget positioning.
@@ -41,6 +42,7 @@ from notifier import ReminderScheduler
 from notes_window import NotesWindow
 from settings_window import SettingsWindow
 from replacements import apply_replacements
+from agent_panel import AgentPanel
 import audio_cues
 
 _pipeline_queue   = queue.Queue()
@@ -50,6 +52,7 @@ recorder    = Recorder()
 transcriber = None
 tray        = None
 widget      = None
+agent_panel = None
 root        = None
 notes_win   = None
 settings_win = None
@@ -203,8 +206,9 @@ def _begin_recording(mode: str) -> int:
             if hotkey_listener:
                 if stale == "dictation":
                     hotkey_listener.reset_dictation_state()
-                else:
+                elif stale == "assistant":
                     hotkey_listener.reset_assistant_state()
+                # other owners (e.g. "confirm") have no hotkey flag to reset
         _rec_generation += 1
         generation = _rec_generation
         _active_mode = mode
@@ -320,6 +324,8 @@ def _on_hotkey_release():
 
 def _on_assist_press():
     _begin_recording("assistant")
+    if agent_panel:
+        agent_panel.hide()   # answering a pending confirm → dismiss the panel
     if tray:
         tray.set_recording(True)
     if widget:
@@ -389,21 +395,21 @@ def _set_pending_delete(kind: str, item_id: int):
         "expires_at": time.monotonic() + _DELETE_CONFIRM_SECONDS,
     }
 
-    def _open_dialog():
-        try:
-            if not notes_win:
-                return
+    # Ask for confirmation in the floating agent panel (no separate popup):
+    # the user answers by voice; the panel counts down and calls back on
+    # timeout. The old Notes-window dialog is no longer used.
+    if widget:
+        widget.hide()
+    if agent_panel:
+        prompt = locales.get("delete_confirm_widget",
+                             item=locales.get(f"delete_item_{kind}"))
+        agent_panel.show_confirm(prompt, _DELETE_CONFIRM_SECONDS,
+                                 on_timeout=_on_confirm_timeout,
+                                 hint=locales.get("delete_confirm_answer"))
 
-            if not (notes_win._win and notes_win._win.winfo_exists()):
-                notes_win.show("notes")
-
-            notes_win.show_voice_delete_confirmation(kind, item_id)
-            log.info("Pending delete dialog opened: %s #%d", kind, item_id)
-
-        except Exception as exc:
-            log.error("Could not open voice delete dialog: %s", exc)
-
-    _run_on_ui_thread(_open_dialog)
+    # Auto-listen for the spoken yes/no answer — no extra hotkey press needed.
+    if transcriber is not None:
+        threading.Thread(target=_confirm_listen, daemon=True).start()
 
     log.info(
         "Pending delete set: %s #%d (expires in %.1fs)",
@@ -415,6 +421,81 @@ def _set_pending_delete(kind: str, item_id: int):
 def _clear_pending_delete():
     global _pending_delete
     _pending_delete = None
+
+
+def _on_confirm_timeout():
+    """Runs on the Tk thread when the panel countdown elapses unanswered."""
+    if _pending_delete is None:
+        return
+    log.info("Pending delete timed out (no confirmation).")
+    _clear_pending_delete()
+    if agent_panel:
+        agent_panel.hide()
+    if widget:
+        widget.set_expression("sad")
+        widget.show_message(locales.get("delete_confirm_timeout"), 2200)
+
+
+_CONFIRM_LISTEN_SECONDS = 4.0
+
+def _confirm_listen():
+    """Auto-listen for the spoken yes/no answer while a delete is pending.
+
+    The user just says 'yes'/'no' — no need to press the assistant hotkey
+    again. Runs on a background thread: records a short window, transcribes,
+    and resolves; retries on an unclear/empty answer until the pending delete
+    is resolved or its countdown expires. Backs off if the user grabs the mic
+    via the hotkey (that path answers instead)."""
+    attempts = 3
+    while _pending_delete is not None and attempts > 0:
+        attempts -= 1
+        time.sleep(0.5)
+        if _pending_delete is None:
+            return
+        if _active_mode is not None:
+            # user is recording via the hotkey — let that path answer
+            time.sleep(0.4)
+            attempts += 1
+            continue
+        _begin_recording("confirm")   # dedicated owner, isolated from hotkeys
+        time.sleep(_CONFIRM_LISTEN_SECONDS)
+        audio = _end_recording("confirm")
+        if _pending_delete is None:
+            return
+        if audio is None or len(audio) == 0:
+            continue
+        try:
+            # Force the app language: autodetect on a lone "sì"/"yes" is
+            # unreliable and often mis-transcribes it as another language.
+            text = transcriber.transcribe(audio, language=config.LANGUAGE)
+        except Exception as exc:
+            log.error("Confirm-listen transcription failed: %s", exc)
+            return
+        log.info("Confirm-listen heard: %r", text)
+        result = _handle_pending_delete_confirmation(text)
+        if result is None:
+            return
+        if result.startswith("__delete_confirm_repeat__"):
+            continue  # ambiguous/empty answer → listen again
+        _apply_confirm_result(result)
+        return
+
+
+def _apply_confirm_result(result: str):
+    """Show the outcome of an auto-listened confirmation and dismiss the panel."""
+    if agent_panel:
+        agent_panel.hide()
+    if not widget:
+        return
+    if result == "__delete_confirm_timeout__":
+        widget.set_expression("sad")
+        widget.show_message(locales.get("delete_confirm_timeout"), 2200)
+    elif result == "__delete_cancelled__":
+        widget.set_expression("sad")
+        widget.show_message(locales.get("delete_cancelled"), 2200)
+    else:
+        widget.set_expression("happy")
+        widget.show_message("✓", 2000)
 
 def _close_voice_delete_dialog():
     """Close/hide the voice delete dialog on the Tk main thread."""
@@ -433,30 +514,37 @@ def _close_voice_delete_dialog():
     root.after(0, _close)
 
 
-def _matches_locale_choice(text: str, key: str) -> bool:
-    t = " ".join((text or "").strip().lower().split())
+def _fold(s: str) -> str:
+    """Lowercase, collapse whitespace, and strip diacritics.
+
+    So a mis-accented transcription ('si') still matches its locale variant
+    ('sì'), and comparisons never hinge on which accent Whisper produced.
+    """
+    s = " ".join((s or "").strip().lower().split())
+    s = unicodedata.normalize("NFKD", s)
+    return "".join(c for c in s if not unicodedata.combining(c))
+
+
+def _matches_choice_list(text: str, choices) -> bool:
+    t = _fold(text)
     if not t:
         return False
-
-    choices = [
-        " ".join(choice.strip().lower().split())
-        for choice in locales.get_choices(key)
-        if choice.strip()
-    ]
-    if not choices:
+    folded = [c for c in (_fold(choice) for choice in choices) if c]
+    if not folded:
         return False
-
-    alternatives = "|".join(re.escape(choice) for choice in choices)
+    alternatives = "|".join(re.escape(choice) for choice in folded)
     pattern = rf"(?<!\w)(?:{alternatives})(?!\w)"
     return bool(re.search(pattern, t))
 
 
 def _is_affirmative(text: str) -> bool:
-    return _matches_locale_choice(text, "delete_confirmations")
+    # Accept a spoken yes in any supported language: a short confirmation word
+    # is often transcribed under the wrong language, so match across all of them.
+    return _matches_choice_list(text, locales.get_all_choices("delete_confirmations"))
 
 
 def _is_negative(text: str) -> bool:
-    return _matches_locale_choice(text, "delete_rejections")
+    return _matches_choice_list(text, locales.get_all_choices("delete_rejections"))
 
 
 def _refresh_notes_window_if_open():
@@ -570,17 +658,7 @@ def _assistant_worker():
             token = _parse_delete_token(result)
             if token:
                 kind, item_id = token
-                _set_pending_delete(kind, item_id)
-                if widget:
-                    widget.set_expression("listening")
-                    widget.show_message(
-                        locales.get(
-                            "delete_confirm_prompt",
-                            item=locales.get(f"delete_item_{kind}"),
-                            seconds=int(_DELETE_CONFIRM_SECONDS),
-                        ),
-                        2200,
-                    )
+                _set_pending_delete(kind, item_id)  # shows the inline confirm
                 continue
 
             # Handle special show commands
@@ -594,9 +672,13 @@ def _assistant_worker():
                     widget.show_message(locales.get("delete_cancelled"), 2200)
             elif result.startswith("__delete_confirm_repeat__:"):
                 remaining = int(result.rsplit(":", 1)[1])
-                if widget:
-                    widget.set_expression("listening")
-                    widget.show_message(locales.get("delete_confirm_repeat", seconds=remaining), 2200)
+                if agent_panel and _pending_delete:
+                    prompt = locales.get(
+                        "delete_confirm_widget",
+                        item=locales.get(f"delete_item_{_pending_delete['kind']}"))
+                    agent_panel.show_confirm(
+                        prompt, remaining, on_timeout=_on_confirm_timeout,
+                        hint=locales.get("delete_confirm_answer"))
             elif result == "__show_notes__":
                 if notes_win:
                     root.after(0, lambda: notes_win.show("notes"))
@@ -869,7 +951,7 @@ def _finish_startup():
 
 
 def main():
-    global tray, widget, root, notes_win, settings_win
+    global tray, widget, agent_panel, root, notes_win, settings_win
 
     _mutex = _acquire_instance_lock()
 
@@ -880,6 +962,7 @@ def main():
     root.withdraw()
 
     widget = RecordingWidget(root)
+    agent_panel = AgentPanel(root)
     notes_win = NotesWindow(root)
     settings_win = SettingsWindow(root)
 

--- a/test_inline_confirm.py
+++ b/test_inline_confirm.py
@@ -1,0 +1,113 @@
+"""Voice-delete confirmation now uses the floating agent panel (main.py).
+
+The confirmation moved from a separate Notes-window popup into the dedicated
+AgentPanel: _set_pending_delete shows the rich confirm card with a live
+countdown, and the panel calls _on_confirm_timeout when it elapses unanswered.
+
+Run:  python -m unittest test_inline_confirm -v
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import config
+import main
+
+
+class TestInlineConfirm(unittest.TestCase):
+    def setUp(self):
+        main._pending_delete = None
+
+    def tearDown(self):
+        main._pending_delete = None
+
+    def test_set_pending_delete_shows_panel_and_hides_pill(self):
+        panel, pill = Mock(), Mock()
+        with patch.object(main, "agent_panel", panel), \
+             patch.object(main, "widget", pill), \
+             patch.object(config, "LANGUAGE", "en"):
+            main._set_pending_delete("note", 7)
+
+        self.assertEqual(main._pending_delete["kind"], "note")
+        self.assertEqual(main._pending_delete["id"], 7)
+        pill.hide.assert_called_once()          # pill dismissed
+        panel.show_confirm.assert_called_once()
+        args, kwargs = panel.show_confirm.call_args
+        self.assertEqual(args[0], "Delete note?")   # localized, no seconds baked in
+        self.assertEqual(args[1], main._DELETE_CONFIRM_SECONDS)
+        self.assertIs(kwargs["on_timeout"], main._on_confirm_timeout)
+
+    def test_set_pending_delete_does_not_open_notes_popup(self):
+        notes = Mock()
+        with patch.object(main, "agent_panel", Mock()), \
+             patch.object(main, "widget", Mock()), \
+             patch.object(main, "notes_win", notes):
+            main._set_pending_delete("appointment", 3)
+        notes.show_voice_delete_confirmation.assert_not_called()
+
+    def test_timeout_clears_pending_hides_panel_and_notifies(self):
+        panel, pill = Mock(), Mock()
+        main._pending_delete = {"kind": "note", "id": 7, "expires_at": 0.0}
+        with patch.object(main, "agent_panel", panel), \
+             patch.object(main, "widget", pill), \
+             patch.object(config, "LANGUAGE", "en"):
+            main._on_confirm_timeout()
+
+        self.assertIsNone(main._pending_delete)
+        panel.hide.assert_called_once()
+        pill.set_expression.assert_called_with("sad")
+        pill.show_message.assert_called_once()
+
+    def test_timeout_is_noop_when_nothing_pending(self):
+        panel = Mock()
+        main._pending_delete = None
+        with patch.object(main, "agent_panel", panel), patch.object(main, "widget", Mock()):
+            main._on_confirm_timeout()
+        panel.hide.assert_not_called()
+
+    def test_set_pending_delete_starts_autolisten_when_ready(self):
+        with patch.object(main, "agent_panel", Mock()), \
+             patch.object(main, "widget", Mock()), \
+             patch.object(main, "transcriber", Mock()), \
+             patch.object(main.threading, "Thread") as thread:
+            main._set_pending_delete("note", 1)
+        thread.assert_called_once()
+        self.assertIs(thread.call_args.kwargs["target"], main._confirm_listen)
+        thread.return_value.start.assert_called_once_with()
+
+    def test_set_pending_delete_skips_autolisten_without_transcriber(self):
+        with patch.object(main, "agent_panel", Mock()), \
+             patch.object(main, "widget", Mock()), \
+             patch.object(main, "transcriber", None), \
+             patch.object(main.threading, "Thread") as thread:
+            main._set_pending_delete("note", 1)
+        thread.assert_not_called()
+
+
+class TestApplyConfirmResult(unittest.TestCase):
+    def test_success_shows_check_and_hides_panel(self):
+        panel, pill = Mock(), Mock()
+        with patch.object(main, "agent_panel", panel), patch.object(main, "widget", pill):
+            main._apply_confirm_result("Nota 'x' eliminata (#7)")
+        panel.hide.assert_called_once()
+        pill.set_expression.assert_called_with("happy")
+        pill.show_message.assert_called_once()
+
+    def test_cancelled_shows_sad(self):
+        panel, pill = Mock(), Mock()
+        with patch.object(main, "agent_panel", panel), patch.object(main, "widget", pill), \
+             patch.object(config, "LANGUAGE", "en"):
+            main._apply_confirm_result("__delete_cancelled__")
+        panel.hide.assert_called_once()
+        pill.set_expression.assert_called_with("sad")
+
+    def test_timeout_token_shows_sad(self):
+        panel, pill = Mock(), Mock()
+        with patch.object(main, "agent_panel", panel), patch.object(main, "widget", pill), \
+             patch.object(config, "LANGUAGE", "en"):
+            main._apply_confirm_result("__delete_confirm_timeout__")
+        pill.set_expression.assert_called_with("sad")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/transcriber.py
+++ b/transcriber.py
@@ -8,6 +8,10 @@ import config
 from logger import log
 from replacements import get_initial_prompt
 
+# Sentinel for transcribe(language=...): distinguishes "caller did not specify"
+# (honour config.WHISPER_LANGUAGE) from an explicit None (force autodetect).
+_AUTO = object()
+
 
 def _nvidia_bin_dirs() -> list[str]:
     """Return bin directories of pip-installed NVIDIA CUDA packages.
@@ -100,10 +104,14 @@ class Transcriber:
             )
         log.info("Model loaded.")
 
-    def transcribe(self, audio_np: np.ndarray) -> str:
+    def transcribe(self, audio_np: np.ndarray, language: str = _AUTO) -> str:
+        # Callers may force a recognition language (e.g. a yes/no confirmation,
+        # where autodetect on a single short word is unreliable). When left
+        # unset we honour the configured WHISPER_LANGUAGE (None = autodetect).
+        lang = config.WHISPER_LANGUAGE if language is _AUTO else language
         segments, info = self._model.transcribe(
             audio_np,
-            language=config.WHISPER_LANGUAGE,
+            language=lang,
             beam_size=5,
             vad_filter=True,
             initial_prompt=get_initial_prompt(),


### PR DESCRIPTION
## What changes

Voice-delete confirmation for notes/appointments moves from the old Notes-window popup to a dedicated **floating "Assistant" panel**.

### New `agent_panel.py`
Dark, topmost, borderless confirm card that never steals focus (`WS_EX_NOACTIVATE`): amber gradient border + glow, animated white Pandora eyes, and a **live countdown ring**. Rendered entirely with Pillow (magenta chromakey for transparency). Thread-safe API: `show_confirm(prompt, seconds, on_timeout, hint)` / `hide()`.

### `main.py`
- `_set_pending_delete` hides the pill and shows the panel instead of the Notes popup.
- **Auto-listen**: `_confirm_listen()` records a short window and transcribes the spoken yes/no with no extra hotkey press (dedicated `"confirm"` owner, isolated from the hotkeys).
- `_on_confirm_timeout()` / `_apply_confirm_result()` handle the timeout and outcome.
- Yes/no matching is now **diacritic-insensitive** (`_fold`) and **cross-language**.

### `locales.py` / `transcriber.py`
- New strings `delete_confirm_widget` / `delete_confirm_answer` (EN/IT/DE) + `get_all_choices()`.
- `transcribe(language=...)` to force the recognition language (autodetect on a single short word is unreliable).

## Tests
- `test_inline_confirm.py`: 9 tests, all green.
- Verified live: said "sì" → the note was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
